### PR TITLE
Fix: update import statements to use absolute paths for consistency across modules

### DIFF
--- a/twinkle_eval/__init__.py
+++ b/twinkle_eval/__init__.py
@@ -27,17 +27,17 @@ __version__ = "1.1.0"
 __author__ = "Twinkle AI Team"
 __license__ = "MIT"
 
-from .config import ConfigurationManager, load_config
-from .dataset import Dataset, find_all_evaluation_files
-from .evaluation_strategies import (
+from twinkle_eval.config import ConfigurationManager, load_config
+from twinkle_eval.dataset import Dataset, find_all_evaluation_files
+from twinkle_eval.evaluation_strategies import (
     BoxExtractionStrategy,
     CustomRegexStrategy,
     EvaluationStrategy,
     EvaluationStrategyFactory,
     PatternMatchingStrategy,
 )
-from .evaluators import Evaluator, RateLimiter
-from .exceptions import (
+from twinkle_eval.evaluators import Evaluator, RateLimiter
+from twinkle_eval.exceptions import (
     ConfigurationError,
     DatasetError,
     EvaluationError,
@@ -48,8 +48,8 @@ from .exceptions import (
 )
 
 # 匯入主要類別和函數，方便使用者直接從套件層級使用
-from .main import TwinkleEvalRunner, create_cli_parser
-from .models import LLM, LLMFactory, OpenAIModel
+from twinkle_eval.main import TwinkleEvalRunner, create_cli_parser
+from twinkle_eval.models import LLM, LLMFactory, OpenAIModel
 
 # 定義 __all__ 以控制 from twinkle_eval import * 的行為
 __all__ = [

--- a/twinkle_eval/benchmark.py
+++ b/twinkle_eval/benchmark.py
@@ -6,8 +6,8 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from .logger import log_error, log_info
-from .models import LLMFactory
+from twinkle_eval.logger import log_error, log_info
+from twinkle_eval.models import LLMFactory
 
 
 @dataclass

--- a/twinkle_eval/cli.py
+++ b/twinkle_eval/cli.py
@@ -12,12 +12,12 @@ from typing import List, Optional
 # 確保能夠正確匯入模組
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from .evaluation_strategies import EvaluationStrategyFactory
-from .logger import log_error
-from .main import create_cli_parser
-from .main import main as main_func
-from .models import LLMFactory
-from .results_exporters import ResultsExporterFactory
+from twinkle_eval.evaluation_strategies import EvaluationStrategyFactory
+from twinkle_eval.logger import log_error
+from twinkle_eval.main import create_cli_parser
+from twinkle_eval.main import main as main_func
+from twinkle_eval.models import LLMFactory
+from twinkle_eval.results_exporters import ResultsExporterFactory
 
 
 def main(args: Optional[List[str]] = None) -> int:
@@ -59,7 +59,7 @@ def main(args: Optional[List[str]] = None) -> int:
 
 def print_version():
     """列印版本資訊"""
-    from . import __author__, __version__
+    from twinkle_eval import __author__, __version__
 
     print(f"🌟 Twinkle Eval v{__version__}")
     print(f"作者: {__author__}")

--- a/twinkle_eval/config.py
+++ b/twinkle_eval/config.py
@@ -2,11 +2,11 @@ from typing import Any, Dict
 
 import yaml
 
-from .evaluation_strategies import EvaluationStrategyFactory
-from .exceptions import ConfigurationError, ValidationError
-from .logger import log_error, log_info
-from .models import LLMFactory
-from .validators import ConfigValidator, DatasetValidator
+from twinkle_eval.evaluation_strategies import EvaluationStrategyFactory
+from twinkle_eval.exceptions import ConfigurationError, ValidationError
+from twinkle_eval.logger import log_error, log_info
+from twinkle_eval.models import LLMFactory
+from twinkle_eval.validators import ConfigValidator, DatasetValidator
 
 
 class ConfigurationManager:
@@ -246,7 +246,7 @@ class ConfigurationManager:
 
         try:
             # 嘗試建立 GoogleSheetsService 實例來驗證配置
-            from .google_services import GoogleSheetsService
+            from twinkle_eval.google_services import GoogleSheetsService
 
             sheets_service = GoogleSheetsService(config)
 
@@ -273,7 +273,7 @@ class ConfigurationManager:
 
         try:
             # 嘗試建立 GoogleDriveUploader 實例來驗證配置
-            from .google_services import GoogleDriveUploader
+            from twinkle_eval.google_services import GoogleDriveUploader
 
             drive_uploader = GoogleDriveUploader(config)
 

--- a/twinkle_eval/dataset.py
+++ b/twinkle_eval/dataset.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from datasets import get_dataset_config_names, get_dataset_split_names, load_dataset
 
-from .logger import log_error, log_info, log_warning
+from twinkle_eval.logger import log_error, log_info, log_warning
 
 
 class Dataset:

--- a/twinkle_eval/evaluators.py
+++ b/twinkle_eval/evaluators.py
@@ -6,10 +6,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from tqdm import tqdm
 
-from .dataset import Dataset
-from .evaluation_strategies import EvaluationStrategy
-from .logger import log_error
-from .models import LLM
+from twinkle_eval.dataset import Dataset
+from twinkle_eval.evaluation_strategies import EvaluationStrategy
+from twinkle_eval.logger import log_error
+from twinkle_eval.models import LLM
 
 
 class RateLimiter:

--- a/twinkle_eval/google_services.py
+++ b/twinkle_eval/google_services.py
@@ -9,9 +9,9 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
-from .exceptions import ConfigurationError
-from .logger import log_error, log_info
-from .results_exporters import ResultsExporter
+from twinkle_eval.exceptions import ConfigurationError
+from twinkle_eval.logger import log_error, log_info
+from twinkle_eval.results_exporters import ResultsExporter
 
 
 class GoogleDriveUploader:

--- a/twinkle_eval/logger.py
+++ b/twinkle_eval/logger.py
@@ -47,7 +47,7 @@ def upload_logs_to_drive(config: Optional[Dict[str, Any]] = None) -> List[Dict[s
         return []
 
     try:
-        from .google_services import GoogleDriveUploader
+        from twinkle_eval.google_services import GoogleDriveUploader
 
         drive_config = config["google_drive"]
         uploader = GoogleDriveUploader(drive_config)

--- a/twinkle_eval/main.py
+++ b/twinkle_eval/main.py
@@ -9,11 +9,11 @@ import numpy as np
 
 from twinkle_eval.exceptions import ConfigurationError
 
-from .config import load_config
-from .dataset import find_all_evaluation_files
-from .evaluators import Evaluator
-from .logger import log_error, log_info
-from .results_exporters import ResultsExporterFactory
+from twinkle_eval.config import load_config
+from twinkle_eval.dataset import find_all_evaluation_files
+from twinkle_eval.evaluators import Evaluator
+from twinkle_eval.logger import log_error, log_info
+from twinkle_eval.results_exporters import ResultsExporterFactory
 
 
 def convert_json_to_html(json_file_path: str) -> int:
@@ -342,7 +342,7 @@ class TwinkleEvalRunner:
         google_drive_config = google_services_config.get("google_drive", {})
         if google_drive_config.get("enabled", False):
             try:
-                from .google_services import GoogleDriveUploader
+                from twinkle_eval.google_services import GoogleDriveUploader
 
                 uploader = GoogleDriveUploader(google_drive_config)
                 upload_info = uploader.upload_latest_files(self.start_time, "logs", "results")
@@ -526,7 +526,7 @@ def main() -> int:
 
     # 處理查詢命令
     if args.list_llms:
-        from .models import LLMFactory
+        from twinkle_eval.models import LLMFactory
 
         print("可用的 LLM 類型:")
         for llm_type in LLMFactory.get_available_types():
@@ -534,7 +534,7 @@ def main() -> int:
         return 0
 
     if args.list_strategies:
-        from .evaluation_strategies import EvaluationStrategyFactory
+        from twinkle_eval.evaluation_strategies import EvaluationStrategyFactory
 
         print("可用的評測策略:")
         for strategy in EvaluationStrategyFactory.get_available_types():
@@ -548,7 +548,7 @@ def main() -> int:
         return 0
 
     if args.version:
-        from . import get_info
+        from twinkle_eval import get_info
 
         info = get_info()
         print(f"🌟 {info['name']} v{info['version']}")
@@ -563,7 +563,7 @@ def main() -> int:
     # HuggingFace 資料集相關命令
     if args.download_dataset:
         try:
-            from .dataset import download_huggingface_dataset
+            from twinkle_eval.dataset import download_huggingface_dataset
 
             download_huggingface_dataset(
                 dataset_name=args.download_dataset,
@@ -579,7 +579,7 @@ def main() -> int:
 
     if args.dataset_info:
         try:
-            from .dataset import list_huggingface_dataset_info
+            from twinkle_eval.dataset import list_huggingface_dataset_info
 
             info = list_huggingface_dataset_info(
                 dataset_name=args.dataset_info, subset=args.dataset_subset
@@ -604,8 +604,8 @@ def main() -> int:
     # Benchmark 命令
     if args.benchmark:
         try:
-            from .benchmark import BenchmarkRunner, print_benchmark_summary, save_benchmark_results
-            from .config import load_config
+            from twinkle_eval.benchmark import BenchmarkRunner, print_benchmark_summary, save_benchmark_results
+            from twinkle_eval.config import load_config
 
             config = load_config(args.config)
             runner = BenchmarkRunner(config)

--- a/twinkle_eval/models.py
+++ b/twinkle_eval/models.py
@@ -5,7 +5,7 @@ import httpx
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
 
-from .logger import log_error
+from twinkle_eval.logger import log_error
 
 
 class LLM(ABC):

--- a/twinkle_eval/results_exporters.py
+++ b/twinkle_eval/results_exporters.py
@@ -725,7 +725,7 @@ class ResultsExporterFactory:
         # 延遲載入 Google Sheets exporter 以避免循環匯入
         if exporter_type == "google_sheets" and cls._registry[exporter_type] is None:
             try:
-                from .google_services import GoogleSheetsExporter
+                from twinkle_eval.google_services import GoogleSheetsExporter
 
                 cls._registry[exporter_type] = GoogleSheetsExporter
             except ImportError as e:

--- a/twinkle_eval/validators.py
+++ b/twinkle_eval/validators.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from .exceptions import ConfigurationError, ValidationError
+from twinkle_eval.exceptions import ConfigurationError, ValidationError
 
 
 class ConfigValidator:


### PR DESCRIPTION
This PR updates import statements to use absolute imports instead of relative imports, ensuring consistent and predictable behavior across modules.

### Motivation

Some modules (e.g. `main.py`) previously relied on relative imports such as:

```python
from .config import load_config
```

When executed directly, this caused the following error:

```
ImportError: attempted relative import with no known parent package
```

This behavior can be confusing for users and makes local development and execution less robust.

### Reference Issue
resolve #11 

### Changes

* Replaced relative imports with absolute imports (e.g. `twinkle_eval.config`)
* Ensured modules can be executed in common usage scenarios without import errors
* Improved consistency with standard Python packaging best practices

### Impact

* No breaking changes to public APIs
* Improves developer experience and runtime reliability
* Aligns the codebase with recommended import conventions for entry-point scripts
