### PR TITLE
chore(release): bump version to 1.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "twinkle-eval"
-version = "1.1.3"
+version = "1.1.4"
 description = "🌟 高效且準確的 AI 模型評測工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/twinkle_eval/__init__.py
+++ b/twinkle_eval/__init__.py
@@ -23,7 +23,7 @@
 授權：MIT License
 """
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __author__ = "Twinkle AI Team"
 __license__ = "MIT"
 


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `twinkle_eval/__init__.py` version from `1.1.3` → `1.1.4`
- Patch release to track the JSONL append-mode fix (commit d776258) merged in the previous push

## Test plan
- [x] `TestVersionConsistency` passes — `__version__` matches `importlib.metadata.version("twinkle-eval")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)