### PR TITLE
chore(release): bump version to 1.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "twinkle-eval"
-version = "1.1.4"
+version = "1.1.5"
 description = "🌟 高效且準確的 AI 模型評測工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/twinkle_eval/__init__.py
+++ b/twinkle_eval/__init__.py
@@ -23,7 +23,7 @@
 授權：MIT License
 """
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __author__ = "Twinkle AI Team"
 __license__ = "MIT"
 


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `twinkle_eval/__init__.py` from `1.1.4` → `1.1.5`
- Patch release tracking PR #23: fallback to `reasoning_content` when `content` is null

## Test plan
- [x] `TestVersionConsistency` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)