### PR TITLE
fix(evaluators): unified reasoning output parsing for inline think tags and null content

### DIFF
--- a/tests/test_reasoning_extraction.py
+++ b/tests/test_reasoning_extraction.py
@@ -116,14 +116,17 @@ class TestInlineThinkTag:
         assert predicted == "B", f"應從 </think> 後提取答案，got: {predicted}"
         assert is_correct is True
 
-    def test_truncated_start_tag_handled(self, tmp_path):
-        """開頭 <think> 被截斷，只剩 </think>Answer: B → 仍能正確提取"""
+    def test_truncated_start_tag_not_stripped(self, tmp_path):
+        """開頭 <think> 被截斷，只剩 </think> → 格式不合格，原樣保留不剝離"""
         evaluator = _make_evaluator()
+        # 只有結尾 tag，沒有開頭 tag → 不剝離，直接對整段 content 提取
+        # 整段含 "答案：B" 仍可被 PatternMatchingStrategy 匹配
         completion = _make_completion(
             content="台灣現行法律規定台北為首都。</think>答案：B",
         )
         predicted, is_correct = _run_single(evaluator, completion, tmp_path)
-        assert predicted == "B", f"截斷 start tag 應仍可提取，got: {predicted}"
+        # 不剝離，但 PatternMatchingStrategy 仍可在原始 content 中找到 "答案：B"
+        assert predicted == "B"
         assert is_correct is True
 
     def test_reason_tag_stripped(self, tmp_path):

--- a/twinkle_eval/evaluators.py
+++ b/twinkle_eval/evaluators.py
@@ -13,16 +13,22 @@ from .logger import log_error
 from .models import LLM
 
 
-_THINK_END_TAGS = ["</think>", "</reason>", "</reasoning>"]
+_THINK_TAG_PAIRS = [
+    ("<think>", "</think>"),
+    ("<reason>", "</reason>"),
+    ("<reasoning>", "</reasoning>"),
+]
 
 
 def _strip_think_blocks(text: str) -> str:
-    """取最後一個推理結尾 tag 之後的內容，兼容開頭 tag 被截斷的情況。"""
+    """剝離完整的推理 tag 對（需同時有開頭與結尾 tag），取結尾 tag 之後的內容。
+    若 tag 不完整（如只有結尾 tag），視為格式不合格，原樣返回。
+    """
     lower = text.lower()
-    for tag in _THINK_END_TAGS:
-        idx = lower.rfind(tag)
-        if idx != -1:
-            return text[idx + len(tag):].strip()
+    for start_tag, end_tag in _THINK_TAG_PAIRS:
+        if start_tag in lower and end_tag in lower:
+            idx = lower.rfind(end_tag)
+            return text[idx + len(end_tag):].strip()
     return text
 
 


### PR DESCRIPTION
## Summary

統一處理推理模型的兩種輸出情境，不需要任何 config 設定：

**情境 A — inline think tag（如 Ollama 等 backend）**
- `content = "<think>推理...</think>答案：B"`
- 自動偵測完整 tag 對並剝離 think block，從結尾提取答案
- 支援 `<think>`、`<reason>`、`<reasoning>`
- **截斷的 tag（只有結尾 tag、缺開頭）視為格式不合格，不處理**

**情境 B — content=null（如推理模型 `skip_special_tokens=true`）**
- fallback 至 `reasoning_content`（原 PR #23 行為，保留）

剝離後 content 為空時自動 fallback 至 `reasoning_content`；兩者皆 null 時記錄錯誤並將該題計為答錯，不 crash。

## 與 PR #18 的差異

PR #18 採用 config-driven 方式（需設 `thinking_start_tag` / `thinking_end_tag`），本 PR 改為自動偵測常見 think tag，使用者無需額外設定。

## Test plan
- [x] 完整 `<think>...</think>Answer` → 剝離後提取答案
- [x] 截斷 tag（只有 `</think>`）→ 不剝離，原樣處理
- [x] `</reason>`、`</reasoning>` tag 同樣處理
- [x] 無 think tag → 原樣不影響
- [x] `content=null` → fallback reasoning_content
- [x] think block 佔滿 content + reasoning_content 有答案 → fallback
- [x] 兩者皆 null → predicted=None，不 crash
- [x] 全套 34 tests 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)