### PR TITLE
feat: Slurm 分散式評測與 HuggingFace 上傳支援 (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-03-16
+
+### Added
+- Slurm 多節點分散式評測支援：每個節點/rank 輸出獨立的 shard JSONL，避免並行寫入衝突
+- `twinkle-eval --finalize-results <timestamp>`：自動合併分散式碎片並重新計算評測指標
+- `twinkle-eval --hf-repo-id` / `--hf-variant`：評測完成後自動上傳結果至 Hugging Face dataset repo
+- `pip install twinkle-eval[slurm]` optional extras：`huggingface-hub` 不再強制安裝；未安裝時呼叫上傳功能會拋出清楚的提示訊息
+- `dataset.py`：自動正規化 MMLU HuggingFace 格式（`choices` list + 整數 `answer`）為 A/B/C/D 具名欄位格式，支援超過 4 個選項
+- `twinkle_eval/finalize.py`：碎片合併邏輯（含備援路徑、清理機制）
+- `twinkle_eval/hf_uploader.py`：HuggingFace Dataset 上傳服務
+- `scripts/`：可直接 sbatch 的 Slurm 腳本（測試版與完整生產版）
+- `configs/`：Slurm 評測設定範例
+- `SLURM_README.md`：分散式評測操作說明
+- `distributed` config 區段：自動從 `WORLD_SIZE`/`RANK` 環境變數讀取分散式設定
+
 ## [1.2.0] - 2026-03-16
 
 ### Added

--- a/SLURM_README.md
+++ b/SLURM_README.md
@@ -1,0 +1,105 @@
+# SLURM 與 vLLM 配置與執行指南
+
+這份文件說明了如何在 SLURM 叢集環境下設定 vLLM 虛擬環境，並透過設定檔配置執行模型評測。
+
+## 1. 初始環境設定 (vLLM 虛擬環境)
+
+在第一次執行任何評測任務之前，必須先建立好專用的 vLLM 虛擬環境。這只需要在專案根目錄執行一次：
+
+```bash
+bash scripts/setup_vllm_venv.sh
+```
+
+此腳本會：
+- 檢查是否安裝了 `uv` 工具（若無則透過 pip 安裝）。
+- 在專案根目錄下建立名為 `vllm-venv` 的虛擬環境 (Python 3.12)。
+- 安裝 vLLM 及相關套件 (PyTorch, Ray 等)，並自動驗證安裝。
+
+## 2. 登入 Hugging Face (必要步驟)
+
+為了讓程式能夠下載受保護的模型（如 Llama 3、Mistral 等）以及上傳評測結果，請確保在叢集的終端機中登入您的 Hugging Face 帳號。
+
+1. 取得您的 Hugging Face Token (確保具有 `write` 權限以上傳結果)。
+2. 執行以下指令登入：
+
+```bash
+hf auth login
+```
+
+這會將 Token 快取記錄於系統中，後續腳本將自動讀取使用。
+
+## 3. 配置 SLURM 任務腳本
+
+專案中提供了 `scripts/run_slurm_test.sh` (測試用) 與 `scripts/run_slurm_full.sh` (完整評測用)，執行前請務必根據您的需求修改檔案內的參數。
+
+### A. SLURM #SBATCH 標頭參數設定
+打開 `scripts/run_slurm_test.sh` 或 `scripts/run_slurm_full.sh`，修改檔案最上方的 `#SBATCH` 設定：
+
+```bash
+#SBATCH --job-name=my-eval-job       # 任務名稱 (識別用)
+#SBATCH --partition=dev              # 佇列分區 (正式評測請用 normal 或 GPU 專用佇列)
+#SBATCH --nodes=1                    # 使用節點數量 (多節點請修改)
+#SBATCH --ntasks-per-node=1          # 每個節點的進程數
+#SBATCH --gres=gpu:H200:8            # 使用 GPU 的規格與數量 (例如 H200 系列要求 8 張)
+#SBATCH --account=YOUR_ACCOUNT       # 計畫代號或扣款帳號
+```
+
+### B. 使用者自定義參數 (腳本內部變數)
+您也可以在腳本中找到以下區塊，根據這次要評測的模型調整變數：
+
+- `MODEL_NAME`: Hugging Face 的模型 ID，例如 `"mistralai/Ministral-3-14B-Instruct-2512"`。
+- `TP_SIZE` (Tensor Parallel Size): 張量平行數量，若模型太大單卡放不下，請設定為卡數 (例如 2, 4, 8) 分散模型權重。
+- `PP_SIZE` (Pipeline Parallel Size): 管線平行數量，針對超大模型跨節點時使用，預設 1 即可。
+- `HF_UPLOAD_REPO`: 評測結果上傳至 Hugging Face 的 Repo 名稱 (例: `your-username/my-eval-logs`)。
+- `MAX_TOKENS` / `MAX_MODEL_LEN`: 生成輸出的 Tokens 上限以及模型支援的最大 Context 長度。
+
+*提示：這些參數也可以在執行 `sbatch` 時透過後接參數覆蓋，例如：*
+```bash
+sbatch scripts/run_slurm_test.sh "mistralai/My-Model" 8 1 "my-org/my-repo"
+```
+
+### C. 評測配置檔參數 (YAML)
+除了腳本中的變數，您也可以修改 `configs/config_slurm_test.yaml` 或 `configs/config_slurm_full.yaml`。雖然這些檔案中的配置（例如 `dataset_paths` 或 System Prompt）較不會頻繁更動，但如果您需要調整特定的評測細節、控制生成數量或其他 `twinkle-eval` 參數，請直接編輯這些 YAML 檔案。
+
+## 4. 執行與監控 SLURM 任務
+
+配置完成後，即可提交任務至排程系統：
+
+```bash
+# 提交測試評測任務
+sbatch scripts/run_slurm_test.sh
+
+# 提交完整評測任務
+sbatch scripts/run_slurm_full.sh
+```
+
+### 常見管理指令：
+
+- **查看任務排程狀態**：
+  ```bash
+  squeue -u <你的帳號>
+  ```
+- **取消任務**：
+  ```bash
+  scancel <JobID>
+  ```
+- **查看即時日誌**：
+  任務送出後，會在專案下的 `logs/` 資料夾產生類似 `slurm_test_<JobID>.out` 及 `.err` 的日誌檔案。可使用 tail 即時查看輸出：
+  ```bash
+  tail -f logs/slurm_test_<JobID>.out
+  ```
+- **監測節點與 GPU 工作狀態**：
+  在叢集中若想查看目前節點的 GPU 使用率與運行狀態，可以使用 `nvnodetop` 工具：
+  ```bash
+  uvx nvnodetop
+  ```
+
+## 5. 評測流程簡述
+
+任務啟動後，執行腳本會自動進行以下流程：
+1. 分析硬體與建立環境配置。
+2. (若需) 下載 tw-legal-benchmark 資料集。
+3. 自動以對應的 GPU 數量啟動本機/多節點的 vLLM OpenAI Server API (`vllm.entrypoints.openai.api_server`)。
+4. 在背景使用 `twinkle-eval` 開始批次傳送 prompt 給 vLLM 解答。
+5. 評等完成後，統一收集 json 結果，合併所有的 shards。
+6. 自動化將成績及日誌推送至您指定的 Hugging Face Repo。

--- a/configs/config_slurm_full.yaml
+++ b/configs/config_slurm_full.yaml
@@ -1,0 +1,69 @@
+llm_api:
+  base_url: "PLACEHOLDER_BASE_URL"
+  api_key: "dummy"
+  disable_ssl_verify: false
+  api_rate_limit: -1
+  max_retries: 5
+  timeout: 1200
+
+model:
+  name: "PLACEHOLDER_MODEL_NAME"
+  temperature: 0.0
+  top_p: 1.0
+  max_tokens: PLACEHOLDER_MAX_TOKENS
+  frequency_penalty: 0.0
+  presence_penalty: 0.0
+  extra_body:
+  thinking_start_tag: PLACEHOLDER_THINKING_START_TAG
+  thinking_end_tag: PLACEHOLDER_THINKING_END_TAG
+
+evaluation:
+  dataset_paths:
+    - "PLACEHOLDER_DATASET_DIR/ikala__tmmluplus/"
+    - "PLACEHOLDER_DATASET_DIR/cais__mmlu/"
+    - "PLACEHOLDER_DATASET_DIR/lianghsun__tw-legal-benchmark-v1/"
+  evaluation_method: "box"
+  system_prompt:
+    zh: |
+      使用者將提供一個題目，並附上選項 A、B、C、D
+      請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
+      \box{選項}
+      請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
+      務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+    en: |
+      The user will provide a question along with options A, B, C, and D.
+      Please read the question carefully and select the option that best fits the requirements.
+      Output the selected option in the following format:
+      \box{Option}
+      Make sure to include only the option within the curly braces; otherwise, it will not be considered a valid answer.
+      Strictly follow the output format and avoid any extra content or incorrect formatting.
+  datasets_prompt_map:
+    "PLACEHOLDER_DATASET_DIR/cais__mmlu/": "en"
+  repeat_runs: 3
+  shuffle_options: true
+
+environment:
+  gpu_info:
+    model: "PLACEHOLDER_GPU_MODEL"
+    count: PLACEHOLDER_GPU_COUNT
+    memory_gb: PLACEHOLDER_GPU_MEMORY_GB
+    cuda_version: "PLACEHOLDER_CUDA_VERSION"
+    driver_version: "PLACEHOLDER_DRIVER_VERSION"
+  parallel_config:
+    tp_size: PLACEHOLDER_TP_SIZE
+    pp_size: PLACEHOLDER_PP_SIZE
+    max_model_len: PLACEHOLDER_MAX_MODEL_LEN
+  system_info:
+    framework: "vLLM"
+    python_version: "PLACEHOLDER_PYTHON_VERSION"
+    torch_version: "PLACEHOLDER_TORCH_VERSION"
+    node_count: PLACEHOLDER_NNODES
+
+logging:
+  level: "INFO"
+
+google_services:
+  google_drive:
+    enabled: false
+  google_sheets:
+    enabled: false

--- a/configs/config_slurm_test.yaml
+++ b/configs/config_slurm_test.yaml
@@ -1,0 +1,66 @@
+llm_api:
+  base_url: "PLACEHOLDER_BASE_URL"
+  api_key: "dummy"
+  disable_ssl_verify: false
+  api_rate_limit: -1
+  max_retries: 5
+  timeout: 1200
+
+model:
+  name: "PLACEHOLDER_MODEL_NAME"
+  temperature: 0.0
+  top_p: 1.0
+  max_tokens: PLACEHOLDER_MAX_TOKENS
+  frequency_penalty: 0.0
+  presence_penalty: 0.0
+  extra_body:
+  thinking_start_tag: PLACEHOLDER_THINKING_START_TAG
+  thinking_end_tag: PLACEHOLDER_THINKING_END_TAG
+
+evaluation:
+  dataset_paths:
+    - "PLACEHOLDER_DATASET_DIR/lianghsun__tw-legal-benchmark-v1/"
+  evaluation_method: "box"
+  system_prompt:
+    zh: |
+      使用者將提供一個題目，並附上選項 A、B、C、D
+      請仔細閱讀題目要求，根據題意選出最符合的選項，並將選項以以下格式輸出：
+      \box{選項}
+      請確保僅將選項包含在 { } 中，否則將不計算為有效答案。
+      務必精確遵循輸出格式，避免任何多餘內容或錯誤格式。
+    en: |
+      The user will provide a question along with options A, B, C, and D.
+      Please read the question carefully and select the option that best fits the requirements.
+      Output the selected option in the following format:
+      \box{Option}
+      Make sure to include only the option within the curly braces; otherwise, it will not be considered a valid answer.
+      Strictly follow the output format and avoid any extra content or incorrect formatting.
+  datasets_prompt_map: {}
+  repeat_runs: 1
+  shuffle_options: false
+
+environment:
+  gpu_info:
+    model: "PLACEHOLDER_GPU_MODEL"
+    count: PLACEHOLDER_GPU_COUNT
+    memory_gb: PLACEHOLDER_GPU_MEMORY_GB
+    cuda_version: "PLACEHOLDER_CUDA_VERSION"
+    driver_version: "PLACEHOLDER_DRIVER_VERSION"
+  parallel_config:
+    tp_size: PLACEHOLDER_TP_SIZE
+    pp_size: PLACEHOLDER_PP_SIZE
+    max_model_len: PLACEHOLDER_MAX_MODEL_LEN
+  system_info:
+    framework: "vLLM"
+    python_version: "PLACEHOLDER_PYTHON_VERSION"
+    torch_version: "PLACEHOLDER_TORCH_VERSION"
+    node_count: PLACEHOLDER_NNODES
+
+logging:
+  level: "INFO"
+
+google_services:
+  google_drive:
+    enabled: false
+  google_sheets:
+    enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "twinkle-eval"
-version = "1.2.0"
+version = "1.3.0"
 description = "🌟 高效且準確的 AI 模型評測工具"
 readme = "README.md"
 license = {text = "MIT"}
@@ -58,6 +58,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+slurm = [
+    "huggingface-hub>=0.20.0",
+]
 math = [
     "mathruler>=0.1.0",
     "sympy>=1.14.0",

--- a/scripts/run_slurm_full.sh
+++ b/scripts/run_slurm_full.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+#SBATCH --job-name=nemotron-nano-full   # <= 請改成你的 job name (識別用)
+#SBATCH --partition=normal              #    全批次請使用 normal
+#SBATCH --nodes=4                       # <= 請改成你的節點數量，normal partition 最少 2 個節點
+#SBATCH --ntasks-per-node=1             #    每台節點的 task 數量
+#SBATCH --gres=gpu:H200:8               #    每台節點的 GPU 數量
+#SBATCH --cpus-per-task=104             #    每台節點的 CPU 數量
+#SBATCH --mem=0                         #    設置為該節點所有記憶體
+#SBATCH --time=2-00:00:00               # <= 請改成你的時間限制
+#SBATCH --output=logs/slurm_full_%j.out #    請改成你的輸出日誌路徑
+#SBATCH --error=logs/slurm_full_%j.err  #    請改成你的錯誤日誌路徑
+#SBATCH --account=YOUR_ACCOUNT          #    請改成你的帳號或計畫代號
+
+set -euo pipefail
+
+# ==============================================================================
+# 使用者定義輸入 (User defined Inputs) - 可透過執行腳本時傳入參數覆蓋
+# ------------------------------------------------------------------------------
+# 1. MODEL_NAME: 欲進行評測的模型名稱。可以是 Hugging Face 上的 Repo ID 
+#                (例如 "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16") 或本地端絕對路徑。
+MODEL_NAME=${1:-"nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"}
+
+# 2. TP_SIZE (Tensor Parallel Size): 決定模型要在單一節點內切分給「幾張 GPU」同時運算。
+#                                    若模型超過單卡 VRAM，請調高此數值。
+TP_SIZE=${2:-1}
+
+# 3. PP_SIZE (Pipeline Parallel Size): 管線平行處理大小。一般針對超大模型才需設定，預設為 1 即可。
+PP_SIZE=${3:-1}
+
+# 4. HF_UPLOAD_REPO: Hugging Face 上用來存放評測結果資料集的 Repo 路徑。
+#                    請確保系統環境已登入 Hugging Face (執行過 `hf auth login`) 且具備寫入權限。
+HF_UPLOAD_REPO=${4:-"whats2000/nemotron-nano-eval-logs-and-scores"}
+
+# 5. 生成控制參數 (Generation Parameters):
+#                MAX_TOKENS: 必須小於 MAX_MODEL_LEN (因為要預留輸入 prompt 的空間)
+MAX_TOKENS=${5:-16384}
+THINKING_START_TAG=${6:-"<think>"}
+THINKING_END_TAG=${7:-"</think>"}
+
+# 6. 伺服器啟動參數 (Server Parameters):
+#    MAX_MODEL_LEN: 模型最大上下文長度 (會影響 vLLM 分配的 GPU 記憶體量)
+MAX_MODEL_LEN=${8:-32768}
+
+# 7. HF_VARIANT: 上傳到 Hugging Face 時的 variant 名稱，用於在同一個 Repo 下區分不同評測條件。
+#               例如："default"、"high", "low" 等表示不同評測條件
+HF_VARIANT=${9:-"default"}
+
+# 8. 工作目錄 (Working Directory): 專案程式碼的根目錄絕對路徑。
+#    留空則自動偵測，如自動偵測失敗再手動填寫。
+WORK_DIR=""                                    # <= 選填，留空自動偵測
+
+# ------------------------------------------------------------------------------
+# ⚠️ 注意 (Notice):
+# 其他如資料集設定 (dataset_paths)、System Prompt 或是較少更動的評測選項，
+# 仍需要直接去修改 yaml 配置檔 (configs/config_slurm_full.yaml)。
+# ==============================================================================
+
+# ==============================================================================
+# 自動偵測 WORK_DIR（請勿修改）
+# ------------------------------------------------------------------------------
+if [ -z "${WORK_DIR}" ]; then
+    if [ -n "${SLURM_SUBMIT_DIR:-}" ]; then
+        # SLURM 環境：使用 sbatch 命令下達時由 SLURM 記錄的路徑
+        WORK_DIR="${SLURM_SUBMIT_DIR}"
+    elif [ -n "${BASH_SOURCE[0]:-}" ] && [ "${BASH_SOURCE[0]}" != "$0" -o -f "${BASH_SOURCE[0]}" ]; then
+        # 本機執行：從腳本本身位置向上一層推導
+        WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        WORK_DIR="$(dirname "${WORK_DIR}")"
+    else
+        echo "ERROR: 無法自動偵測 WORK_DIR，請在上方使用者定義區填寫專案絕對路徑。" >&2
+        exit 1
+    fi
+fi
+# ==============================================================================
+
+mkdir -p logs results
+
+# 確保運算節點上有使用者本地二進制檔 (uv, hf) 於路徑中
+export PATH="$HOME/.local/bin:$HOME/miniconda3/bin:$HOME/miniconda3/condabin:$PATH"
+
+cd "${WORK_DIR}"
+
+# 將 HF/模型快取導向 /work 以避免 /home 空間配額耗盡
+export HF_HOME="/work/${USER}/.cache/huggingface"
+export HF_HUB_CACHE="${HF_HOME}/hub"
+export TRANSFORMERS_CACHE="${HF_HOME}/hub"
+export UV_CACHE_DIR="/work/${USER}/.cache/uv"
+mkdir -p "${HF_HOME}"
+
+# Token: 透過 sbatch --export 傳入；若無則自動讀取 token 快取檔案
+if [[ -z "${HF_TOKEN:-}" ]]; then
+    HF_TOKEN="$(cat "${HF_HOME}/token" 2>/dev/null || cat ~/.cache/huggingface/token 2>/dev/null || true)"
+fi
+: "${HF_TOKEN:?ERROR: HF_TOKEN not set. Run: hf auth login}"
+
+export HF_TOKEN
+export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+
+VLLM_VENV="${WORK_DIR}/vllm-venv"
+if [[ ! -x "${VLLM_VENV}/bin/python" ]]; then
+    echo "ERROR: vllm venv not found at ${VLLM_VENV}" >&2
+    exit 1
+fi
+
+# 計算動態變數
+NNODES=${SLURM_NNODES:-1}
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+INSTANCES_PER_NODE=$(( GPUS_PER_NODE / (TP_SIZE * PP_SIZE) ))
+DP_SIZE=$(( NNODES * INSTANCES_PER_NODE ))
+
+# 環境資訊
+GPU_MODEL=$(nvidia-smi --query-gpu=name --format=csv,noheader -i 0 | xargs)
+GPU_COUNT=$(nvidia-smi --list-gpus | wc -l)
+GPU_MEMORY_MIB=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader -i 0 | awk '{print $1}')
+GPU_MEMORY=$(echo "scale=1; $GPU_MEMORY_MIB / 1024" | bc 2>/dev/null || awk "BEGIN {printf \"%.1f\", $GPU_MEMORY_MIB/1024}")
+CUDA_VERSION=$(nvidia-smi | grep -oP 'CUDA Version: \K[0-9]+\.[0-9]+' | head -1)
+DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader -i 0 | xargs)
+PYTHON_VERSION=$(uv run python --version | awk '{print $2}')
+TORCH_VERSION=$("${VLLM_VENV}/bin/python" -c "import torch; print(torch.__version__)" 2>/dev/null || echo "N/A")
+
+# ==============================================================================
+# 準備資料集 (Dataset Preparation)
+# ------------------------------------------------------------------------------
+DATASET_DIR="/work/${USER}/datasets"
+mkdir -p "${DATASET_DIR}"
+
+if [[ ! -d "${DATASET_DIR}/ikala__tmmluplus" ]]; then
+    echo "正在下載 tmmluplus (test) ..."
+    uv run twinkle-eval --download-dataset ikala/tmmluplus \
+        --dataset-split test \
+        --output-dir "${DATASET_DIR}"
+fi
+
+if [[ ! -d "${DATASET_DIR}/lianghsun__tw-legal-benchmark-v1" ]]; then
+    echo "正在下載 tw-legal-benchmark-v1 (train) ..."
+    uv run twinkle-eval --download-dataset lianghsun/tw-legal-benchmark-v1 \
+        --dataset-split train \
+        --output-dir "${DATASET_DIR}"
+fi
+
+if [[ ! -d "${DATASET_DIR}/cais__mmlu" ]]; then
+    echo "正在下載 mmlu (test) ..."
+    uv run twinkle-eval --download-dataset cais/mmlu \
+        --dataset-split test \
+        --output-dir "${DATASET_DIR}"
+fi
+# ==============================================================================
+
+# 建立動態配置檔
+CONFIG_RUN="configs/run_full_${SLURM_JOB_ID:-test}.yaml"
+cp configs/config_slurm_full.yaml $CONFIG_RUN
+
+# 確保 REPEAT_RUNS 佔位符被正確處理 (如果存在)
+sed -i "s|PLACEHOLDER_MODEL_NAME|${MODEL_NAME}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_DATASET_DIR|${DATASET_DIR}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_MODEL|${GPU_MODEL}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_COUNT|${GPU_COUNT}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_MEMORY_GB|${GPU_MEMORY}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_CUDA_VERSION|${CUDA_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_DRIVER_VERSION|${DRIVER_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_TP_SIZE|${TP_SIZE}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_PP_SIZE|${PP_SIZE}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_PYTHON_VERSION|${PYTHON_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_TORCH_VERSION|${TORCH_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_NNODES|${NNODES}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_REPEAT_RUNS|5|g" $CONFIG_RUN # Full script defaults to 5
+sed -i "s|PLACEHOLDER_MAX_MODEL_LEN|${MAX_MODEL_LEN}|g" $CONFIG_RUN
+
+if [ "$THINKING_START_TAG" = "null" ]; then
+    sed -i "s|PLACEHOLDER_THINKING_START_TAG|null|g" $CONFIG_RUN
+else
+    sed -i "s|PLACEHOLDER_THINKING_START_TAG|\"${THINKING_START_TAG}\"|g" $CONFIG_RUN
+fi
+
+if [ "$THINKING_END_TAG" = "null" ]; then
+    sed -i "s|PLACEHOLDER_THINKING_END_TAG|null|g" $CONFIG_RUN
+else
+    sed -i "s|PLACEHOLDER_THINKING_END_TAG|\"${THINKING_END_TAG}\"|g" $CONFIG_RUN
+fi
+
+sed -i "s|PLACEHOLDER_MAX_TOKENS|${MAX_TOKENS}|g" $CONFIG_RUN
+
+
+echo "============================================="
+echo " 開始完整生產評測 "
+echo " 模型 (MODEL): $MODEL_NAME"
+echo " 策略 (STRATEGY): TP=$TP_SIZE | PP=$PP_SIZE | 總節點數=$NNODES"
+echo " 計算得出每節點實例數: $INSTANCES_PER_NODE (總平行工作數 DP=$DP_SIZE)"
+echo "============================================="
+
+# 在背景啟動多個本地 vLLM 伺服器
+WRAPPER_SCRIPT="run_node_wrapper_${SLURM_JOB_ID:-test}.sh"
+cat << 'EOF' > $WRAPPER_SCRIPT
+#!/bin/bash
+export INSTANCES_PER_NODE=$7
+export RANK_OFFSET=$(( SLURM_NODEID * INSTANCES_PER_NODE ))
+export WORLD_SIZE=$(( SLURM_NNODES * INSTANCES_PER_NODE ))
+VLLM_VENV_PATH="${6}"
+
+echo "[節點 $SLURM_NODEID] 開始啟動 $INSTANCES_PER_NODE 個 vLLM 實例..."
+
+# 清理前次 job 殘留的 /tmp 快取與 /dev/shm 共享記憶體，
+# 避免超過 overcommit 限制導致 mmap 失敗，以及 NCCL /dev/shm 耗盡
+echo "[節點 $SLURM_NODEID] 清理 /tmp 與 /dev/shm 前次殘留..."
+rm -rf /tmp/vllm_cache_* /tmp/inductor_* /tmp/triton_* /tmp/vllm_tmp_* /tmp/tiktoken_rs_* /tmp/xdg_cache_* /tmp/vllm_*.log 2>/dev/null || true
+rm -f /dev/shm/nccl-* /dev/shm/torch_* 2>/dev/null || true
+
+for i in $(seq 0 $((INSTANCES_PER_NODE - 1))); do
+    GLOBAL_RANK=$(( RANK_OFFSET + i ))
+    START_GPU=$(( i * $2 * $3 ))
+    END_GPU=$(( START_GPU + $2 * $3 - 1 ))
+    GPU_LIST=$(seq -s ',' $START_GPU $END_GPU)
+    PORT=$(( 8000 + i ))
+    BASE_URL="http://localhost:${PORT}/v1"
+    
+    LOCAL_CONFIG="${4%.yaml}_rank${GLOBAL_RANK}.yaml"
+    cp "${4}" "$LOCAL_CONFIG"
+    sed -i "s|PLACEHOLDER_BASE_URL|${BASE_URL}|g" "$LOCAL_CONFIG"
+    
+    (
+        export CUDA_VISIBLE_DEVICES=$GPU_LIST
+        export RANK=$GLOBAL_RANK
+        export WORLD_SIZE=$WORLD_SIZE
+        export TORCHINDUCTOR_CACHE_DIR="/tmp/inductor_${GLOBAL_RANK}"
+        export TRITON_CACHE_DIR="/tmp/triton_${GLOBAL_RANK}"
+        export VLLM_CACHE_ROOT="/tmp/vllm_cache_${GLOBAL_RANK}"
+        export XDG_CACHE_HOME="/tmp/xdg_cache_${GLOBAL_RANK}"
+        export TIKTOKEN_RS_CACHE_DIR="/tmp/tiktoken_rs_${GLOBAL_RANK}"
+        export TMPDIR="/tmp/vllm_tmp_${GLOBAL_RANK}"
+
+        mkdir -p "$TMPDIR" "$TIKTOKEN_RS_CACHE_DIR"
+        # 加入啟動延遲錯開，防止動態通訊埠分配產生競爭 (Race Condition)
+        # vLLM 內部會同時使用 `get_open_port()` 尋找 NCCL 初始化通訊埠，
+        # 如果在同一個毫秒啟動，會導致多個實例拿到同一個通訊埠而引發 NCCL error。
+        sleep $(( i * 10 ))
+
+        MAX_VLLM_RETRIES=3
+        VLLM_START_OK=0
+
+        for attempt in $(seq 1 $MAX_VLLM_RETRIES); do
+            echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] 啟動 vLLM (第 $attempt/$MAX_VLLM_RETRIES 次, GPUs: $GPU_LIST, Port: $PORT)..."
+            "${VLLM_VENV_PATH}/bin/python" -m vllm.entrypoints.openai.api_server \
+                --model "${1}" \
+                --tensor-parallel-size "${2}" \
+                --pipeline-parallel-size "${3}" \
+                --port $PORT \
+                --gpu-memory-utilization 0.90 \
+                --max-model-len "${5}" \
+                --limit-mm-per-prompt '{"image": 1}' \
+                --trust-remote-code > "/tmp/vllm_${GLOBAL_RANK}.log" 2>&1 &
+            VLLM_PID=$!
+
+            WAIT_DEADLINE=$(( $(date +%s) + 3600 ))
+            VLLM_READY=0
+            while [ $(date +%s) -lt $WAIT_DEADLINE ]; do
+                if ! kill -0 $VLLM_PID 2>/dev/null; then
+                    echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] vLLM 程序已意外終止 (第 $attempt 次)。"
+                    break
+                fi
+                if curl -s "${BASE_URL}/models" > /dev/null 2>&1; then
+                    VLLM_READY=1
+                    break
+                fi
+                sleep 5
+            done
+
+            if [ $VLLM_READY -eq 1 ]; then
+                VLLM_START_OK=1
+                break
+            fi
+
+            echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] vLLM 第 $attempt 次啟動失敗，正在終止程序..."
+            kill $VLLM_PID 2>/dev/null || true
+            wait $VLLM_PID 2>/dev/null || true
+
+            if [ $attempt -lt $MAX_VLLM_RETRIES ]; then
+                echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] 等待 30 秒後重試..."
+                sleep 30
+            fi
+        done
+
+        if [ $VLLM_START_OK -eq 0 ]; then
+            echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] vLLM 重試 ${MAX_VLLM_RETRIES} 次均失敗，取消整個 SLURM Job 以防止其他節點無效 hanging..."
+            # copy the vLLM log for inspection
+            mkdir -p logs
+            cp "/tmp/vllm_${GLOBAL_RANK}.log" "logs/vllm_node${SLURM_NODEID}_rank${GLOBAL_RANK}.log" 2>/dev/null || true
+            scancel "${SLURM_JOB_ID}"
+            exit 1
+        fi
+
+        echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] vLLM 就緒。開始評測 (本機寫入)..."
+        uv run twinkle-eval --config "$LOCAL_CONFIG" --export json
+        
+        echo "[節點 $SLURM_NODEID | Rank $GLOBAL_RANK] 評測完成。"
+        kill $VLLM_PID
+        rm -f "$LOCAL_CONFIG"
+    ) &
+done
+
+wait
+EOF
+chmod +x $WRAPPER_SCRIPT
+
+echo "透過 srun 部署任務到各個節點..."
+
+# 在啟動所有 worker 之前，由 head node 統一記錄並匯出固定時間戳。
+# SLURM 會自動將已匯出的環境變數傳遞給所有 srun task，
+# 確保所有 node/rank 使用相同的時間戳，避免跨分鐘邊界造成合併失敗。
+RUN_TIMESTAMP=$(date +"%Y%m%d_%H%M")
+export TWINKLE_EVAL_RUN_TIMESTAMP="${RUN_TIMESTAMP}"
+echo "本次評測時間戳 (RUN_TIMESTAMP): ${RUN_TIMESTAMP}"
+
+START_TIME=$(date +%s)
+
+# srun 會自動在每一個分配到的節點上執行封裝腳本並設定 SLURM_NODEID
+# --wait=0: 不在某一個 task 提前完成時終止其他仍在執行的 tasks
+srun --ntasks="${NNODES}" --ntasks-per-node=1 --nodes="${NNODES}" --wait=0 \
+    bash $WRAPPER_SCRIPT "${MODEL_NAME}" "${TP_SIZE}" "${PP_SIZE}" "${CONFIG_RUN}" "${MAX_MODEL_LEN}" "${VLLM_VENV}" "${INSTANCES_PER_NODE}" || true
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+echo "完整評測完成，共耗時 $DURATION 秒。"
+
+rm -f $CONFIG_RUN $WRAPPER_SCRIPT
+
+# ==========================================
+# 合併評測結果與上傳
+# ==========================================
+echo "等待檔案系統同步..."
+sleep 5
+
+# 直接使用本次 job 開始時統一設定的 RUN_TIMESTAMP，不再動態掃描。
+# 這避免了多節點在不同分鐘啟動時產生不同時間戳、導致合併遺漏碎片的問題。
+if [ -n "${RUN_TIMESTAMP:-}" ]; then
+    # 清點實際寫出的 JSON shard 數是否符合預期 rank 數
+    # 多節點腳本：預期 DP_SIZE (= NNODES × INSTANCES_PER_NODE) 個 shard
+    EXPECTED_SHARDS=${DP_SIZE}
+    # 同時支援兩種檔案格式：
+    #   多 rank： results_{ts}_node*_rank*.json  (world_size > 1)
+    #   單 rank： results_{ts}.json              (world_size = 1)
+    ACTUAL_SHARDS=$(find results/ -maxdepth 1 -name "results_${RUN_TIMESTAMP}_node*_rank*.json" 2>/dev/null | wc -l)
+    if [ "${ACTUAL_SHARDS}" -eq 0 ]; then
+        # 回落檢查單節點無後綴格式
+        if [ -f "results/results_${RUN_TIMESTAMP}.json" ]; then
+            ACTUAL_SHARDS=1
+        fi
+    fi
+
+    echo "=========================================="
+    echo "Shard 清點：預期 ${EXPECTED_SHARDS} 個，實際找到 ${ACTUAL_SHARDS} 個 (Timestamp: ${RUN_TIMESTAMP})"
+
+    if [ "${ACTUAL_SHARDS}" -eq 0 ]; then
+        echo "❌ 找不到任何 shard 檔案，可能所有節點均評測失敗，中止合併。"
+        exit 1
+    elif [ "${ACTUAL_SHARDS}" -lt "${EXPECTED_SHARDS}" ]; then
+        echo "⚠️  警告：僅收到 ${ACTUAL_SHARDS}/${EXPECTED_SHARDS} 個 shard，部分節點/rank 可能失敗，結果將不完整。"
+    else
+        echo "✅ Shard 數量符合預期，開始合併與上傳..."
+    fi
+
+    if [ -n "$HF_UPLOAD_REPO" ] && [ "$HF_UPLOAD_REPO" != "your-org/eval-logs" ]; then
+        uv run twinkle-eval --finalize-results "${RUN_TIMESTAMP}" --hf-repo-id "${HF_UPLOAD_REPO}" --hf-variant "${HF_VARIANT}"
+    else
+        uv run twinkle-eval --finalize-results "${RUN_TIMESTAMP}"
+    fi
+else
+    echo "⚠️ 找不到任何可供處理的評測結果，請確認各節點評測是否已完成並寫入 results/ 目錄。"
+fi

--- a/scripts/run_slurm_test.sh
+++ b/scripts/run_slurm_test.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+#SBATCH --job-name=nemotron-nano-test   # <= 請改成你的 job name (識別用)
+#SBATCH --partition=dev                 #    測試用請使用 dev
+#SBATCH --nodes=1                       #    請改成你的節點數量，normal partition 最少 2 個節點
+#SBATCH --ntasks-per-node=1             #    每台節點的 task 數量
+#SBATCH --gres=gpu:H200:8               #    每台節點的 GPU 數量
+#SBATCH --cpus-per-task=104             #    每台節點的 CPU 數量
+#SBATCH --mem=0                         #    設置為該節點所有記憶體
+#SBATCH --time=01:30:00                 #    測試用不會太長
+#SBATCH --output=logs/slurm_test_%j.out #    輸出日誌
+#SBATCH --error=logs/slurm_test_%j.err  #    錯誤日誌
+#SBATCH --account=YOUR_ACCOUNT          # <= 請改成你的帳號或計畫代號
+
+set -euo pipefail
+
+# ==============================================================================
+# 使用者定義輸入 (User defined Inputs) - 可透過執行腳本時傳入參數覆蓋
+# ------------------------------------------------------------------------------
+# 1. MODEL_NAME: 欲進行評測的模型名稱。可以是 Hugging Face 上的 Repo ID 
+#                (例如 "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16") 或本地端絕對路徑。
+MODEL_NAME=${1:-"nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"}
+
+# 2. TP_SIZE (Tensor Parallel Size): 決定模型要在單一節點內切分給「幾張 GPU」同時運算。
+#                                    若模型超過單卡 VRAM，請調高此數值。
+TP_SIZE=${2:-1}
+
+# 3. PP_SIZE (Pipeline Parallel Size): 管線平行處理大小。一般針對超大模型才需設定，預設為 1 即可。
+PP_SIZE=${3:-1}
+
+# 4. HF_UPLOAD_REPO: Hugging Face 上用來存放評測結果資料集的 Repo 路徑。
+#                    請確保系統環境已登入 Hugging Face (執行過 `hf auth login`) 且具備寫入權限。
+HF_UPLOAD_REPO=${4:-"whats2000/nemotron-nano-test-logs-and-scores"}
+
+# 5. 生成控制參數 (Generation Parameters):
+MAX_TOKENS=${5:-4096}
+THINKING_START_TAG=${6:-"<think>"}
+THINKING_END_TAG=${7:-"</think>"}
+
+# 6. 伺服器啟動參數 (Server Parameters):
+#    MAX_MODEL_LEN: 模型最大上下文長度 (會影響 vLLM 分配的 GPU 記憶體量)
+MAX_MODEL_LEN=${8:-32768}
+
+# 7. HF_VARIANT: 上傳到 Hugging Face 時的 variant 名稱，用於在同一個 Repo 下區分不同評測條件。
+#               例如："test_calibration"、"high-temperature"、"baseline" 等。
+HF_VARIANT=${9:-"test_calibration"}
+
+# 8. 工作目錄 (Working Directory): 專案程式碼的根目錄絕對路徑。
+#    留空則自動偵測，如自動偵測失敗再手動填寫。
+WORK_DIR=""                                    # <= 選填，留空自動偵測
+
+# ------------------------------------------------------------------------------
+# ⚠️ 注意 (Notice):
+# 其他如資料集設定 (dataset_paths)、System Prompt 或是較少更動的評測選項，
+# 仍需要直接去修改 yaml 配置檔 (configs/config_slurm_test.yaml)。
+# ==============================================================================
+
+# ==============================================================================
+# 自動偵測 WORK_DIR（請勿修改）
+# ------------------------------------------------------------------------------
+if [ -z "${WORK_DIR}" ]; then
+    if [ -n "${SLURM_SUBMIT_DIR:-}" ]; then
+        # SLURM 環境：使用 sbatch 命令下達時由 SLURM 記錄的路徑
+        WORK_DIR="${SLURM_SUBMIT_DIR}"
+    elif [ -n "${BASH_SOURCE[0]:-}" ] && [ "${BASH_SOURCE[0]}" != "$0" -o -f "${BASH_SOURCE[0]}" ]; then
+        # 本機執行：從腳本本身位置向上一層推導
+        WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        WORK_DIR="$(dirname "${WORK_DIR}")"
+    else
+        echo "ERROR: 無法自動偵測 WORK_DIR，請在上方使用者定義區填寫專案絕對路徑。" >&2
+        exit 1
+    fi
+fi
+# ==============================================================================
+
+mkdir -p logs results
+
+# 確保運算節點上有使用者本地二進制檔 (uv, hf) 於路徑中
+export PATH="$HOME/.local/bin:$HOME/miniconda3/bin:$HOME/miniconda3/condabin:$PATH"
+
+cd "${WORK_DIR}"
+
+# 將 HF/模型快取導向 /work 以避免 /home 空間配額耗盡
+export HF_HOME="/work/${USER}/.cache/huggingface"
+export HF_HUB_CACHE="${HF_HOME}/hub"
+export TRANSFORMERS_CACHE="${HF_HOME}/hub"
+export UV_CACHE_DIR="/work/${USER}/.cache/uv"
+mkdir -p "${HF_HOME}"
+
+# Token: 透過 sbatch --export 傳入；若無則自動讀取 token 快取檔案
+if [[ -z "${HF_TOKEN:-}" ]]; then
+    HF_TOKEN="$(cat "${HF_HOME}/token" 2>/dev/null || cat ~/.cache/huggingface/token 2>/dev/null || true)"
+fi
+: "${HF_TOKEN:?ERROR: HF_TOKEN not set. Run: hf auth login}"
+
+export HF_TOKEN
+export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+
+VLLM_VENV="${WORK_DIR}/vllm-venv"
+if [[ ! -x "${VLLM_VENV}/bin/python" ]]; then
+    echo "ERROR: vllm venv not found at ${VLLM_VENV}" >&2
+    exit 1
+fi
+
+# 計算動態變數
+NNODES=${SLURM_NNODES:-1}
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+INSTANCES_PER_NODE=$(( GPUS_PER_NODE / (TP_SIZE * PP_SIZE) ))
+
+# 環境資訊
+GPU_MODEL=$(nvidia-smi --query-gpu=name --format=csv,noheader -i 0 | xargs)
+GPU_COUNT=$(nvidia-smi --list-gpus | wc -l)
+GPU_MEMORY_MIB=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader -i 0 | awk '{print $1}')
+GPU_MEMORY=$(echo "scale=1; $GPU_MEMORY_MIB / 1024" | bc 2>/dev/null || awk "BEGIN {printf \"%.1f\", $GPU_MEMORY_MIB/1024}")
+CUDA_VERSION=$(nvidia-smi | grep -oP 'CUDA Version: \K[0-9]+\.[0-9]+' | head -1)
+DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader -i 0 | xargs)
+PYTHON_VERSION=$(uv run python --version | awk '{print $2}')
+TORCH_VERSION=$("${VLLM_VENV}/bin/python" -c "import torch; print(torch.__version__)" 2>/dev/null || echo "N/A")
+
+# ==============================================================================
+# 準備資料集 (Dataset Preparation)
+# ------------------------------------------------------------------------------
+DATASET_DIR="/work/${USER}/datasets"
+mkdir -p "${DATASET_DIR}"
+
+if [[ ! -d "${DATASET_DIR}/lianghsun__tw-legal-benchmark-v1" ]]; then
+    echo "正在下載 tw-legal-benchmark-v1 ..."
+    uv run twinkle-eval --download-dataset lianghsun/tw-legal-benchmark-v1 \
+        --dataset-split train \
+        --output-dir "${DATASET_DIR}"
+fi
+# ==============================================================================
+
+# 建立動態配置檔
+CONFIG_RUN="configs/run_test_${SLURM_JOB_ID:-test}.yaml"
+cp configs/config_slurm_test.yaml.yaml $CONFIG_RUN 2>/dev/null || true
+cp configs/config_slurm_test.yaml $CONFIG_RUN
+
+sed -i "s|PLACEHOLDER_MODEL_NAME|${MODEL_NAME}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_DATASET_DIR|${DATASET_DIR}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_MODEL|${GPU_MODEL}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_COUNT|${GPU_COUNT}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_GPU_MEMORY_GB|${GPU_MEMORY}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_CUDA_VERSION|${CUDA_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_DRIVER_VERSION|${DRIVER_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_TP_SIZE|${TP_SIZE}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_PP_SIZE|${PP_SIZE}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_PYTHON_VERSION|${PYTHON_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_TORCH_VERSION|${TORCH_VERSION}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_NNODES|${NNODES}|g" $CONFIG_RUN
+sed -i "s|PLACEHOLDER_MAX_MODEL_LEN|${MAX_MODEL_LEN}|g" $CONFIG_RUN
+
+# 如果 tags 是字串 "null"，在 YAML 中應該要是 null 關鍵字，我們可以根據變數值決定替換格式
+if [ "$THINKING_START_TAG" = "null" ]; then
+    sed -i "s|PLACEHOLDER_THINKING_START_TAG|null|g" $CONFIG_RUN
+else
+    sed -i "s|PLACEHOLDER_THINKING_START_TAG|\"${THINKING_START_TAG}\"|g" $CONFIG_RUN
+fi
+
+if [ "$THINKING_END_TAG" = "null" ]; then
+    sed -i "s|PLACEHOLDER_THINKING_END_TAG|null|g" $CONFIG_RUN
+else
+    sed -i "s|PLACEHOLDER_THINKING_END_TAG|\"${THINKING_END_TAG}\"|g" $CONFIG_RUN
+fi
+
+sed -i "s|PLACEHOLDER_MAX_TOKENS|${MAX_TOKENS}|g" $CONFIG_RUN
+
+echo "============================================="
+echo " 開始校準測試 "
+echo " 模型 (MODEL): $MODEL_NAME"
+echo " 策略 (STRATEGY): TP=$TP_SIZE | PP=$PP_SIZE | 實例數/節點=$INSTANCES_PER_NODE"
+echo "============================================="
+
+# 在啟動所有 worker 之前，統一記錄並匯出固定時間戳。
+# 所有 rank subshell 都會繼承此環境變數，確保使用相同時間戳，避免合併失敗。
+RUN_TIMESTAMP=$(date +"%Y%m%d_%H%M")
+export TWINKLE_EVAL_RUN_TIMESTAMP="${RUN_TIMESTAMP}"
+echo "本次評測時間戳 (RUN_TIMESTAMP): ${RUN_TIMESTAMP}"
+
+START_TIME=$(date +%s)
+
+# 清理前次 job 殘留的 /tmp 快取與 /dev/shm 共享記憶體，
+# 避免超過 overcommit 限制導致 mmap 失敗，以及 NCCL /dev/shm 耗盡
+echo "清理 /tmp 與 /dev/shm 前次殘留..."
+rm -rf /tmp/vllm_cache_* /tmp/inductor_* /tmp/triton_* /tmp/vllm_tmp_test_* /tmp/tiktoken_rs_* /tmp/xdg_cache_* /tmp/vllm_*.log 2>/dev/null || true
+rm -f /dev/shm/nccl-* /dev/shm/torch_* 2>/dev/null || true
+
+for i in $(seq 0 $((INSTANCES_PER_NODE - 1))); do
+    START_GPU=$(( i * TP_SIZE * PP_SIZE ))
+    END_GPU=$(( START_GPU + TP_SIZE * PP_SIZE - 1 ))
+    GPU_LIST=$(seq -s ',' $START_GPU $END_GPU)
+    PORT=$(( 8000 + i ))
+    BASE_URL="http://localhost:${PORT}/v1"
+    
+    LOCAL_CONFIG="${CONFIG_RUN%.yaml}_rank${i}.yaml"
+    cp "${CONFIG_RUN}" "$LOCAL_CONFIG"
+    sed -i "s|PLACEHOLDER_BASE_URL|${BASE_URL}|g" "$LOCAL_CONFIG"
+    
+    (
+        export CUDA_VISIBLE_DEVICES=$GPU_LIST
+        export RANK=$i
+        export WORLD_SIZE=$INSTANCES_PER_NODE
+        export TORCHINDUCTOR_CACHE_DIR="/tmp/inductor_${i}"
+        export TRITON_CACHE_DIR="/tmp/triton_${i}"
+        export VLLM_CACHE_ROOT="/tmp/vllm_cache_${i}"
+        export XDG_CACHE_HOME="/tmp/xdg_cache_${i}"
+        export TIKTOKEN_RS_CACHE_DIR="/tmp/tiktoken_rs_${i}"
+        export TMPDIR="/tmp/vllm_tmp_test_${i}"
+
+        mkdir -p "$TMPDIR" "$TIKTOKEN_RS_CACHE_DIR"
+        # 加入啟動延遲錯開，防止動態通訊埠分配產生競爭 (Race Condition)
+        # vLLM 內部會同時使用 `get_open_port()` 尋找 NCCL 初始化通訊埠，
+        # 如果在同一個毫秒啟動，會導致多個實例拿到同一個通訊埠而引發 NCCL error。
+        sleep $(( i * 10 ))
+
+        MAX_VLLM_RETRIES=3
+        VLLM_START_OK=0
+
+        for attempt in $(seq 1 $MAX_VLLM_RETRIES); do
+            echo "[Rank $i] 啟動 vLLM (第 $attempt/$MAX_VLLM_RETRIES 次, GPUs: $GPU_LIST, Port: $PORT)..."
+            "${VLLM_VENV}/bin/python" -m vllm.entrypoints.openai.api_server \
+                --model "${MODEL_NAME}" \
+                --tensor-parallel-size "${TP_SIZE}" \
+                --pipeline-parallel-size "${PP_SIZE}" \
+                --port "${PORT}" \
+                --gpu-memory-utilization 0.90 \
+                --max-model-len "${MAX_MODEL_LEN}" \
+                --trust-remote-code > "logs/vllm_test_rank${i}.log" 2>&1 &
+            VLLM_PID=$!
+
+            WAIT_DEADLINE=$(( $(date +%s) + 3600 ))
+            VLLM_READY=0
+            while [ $(date +%s) -lt $WAIT_DEADLINE ]; do
+                if ! kill -0 $VLLM_PID 2>/dev/null; then
+                    echo "[Rank $i] vLLM 程序已意外終止 (第 $attempt 次)。"
+                    break
+                fi
+                if curl -s "${BASE_URL}/models" > /dev/null 2>&1; then
+                    VLLM_READY=1
+                    break
+                fi
+                sleep 5
+            done
+
+            if [ $VLLM_READY -eq 1 ]; then
+                VLLM_START_OK=1
+                break
+            fi
+
+            echo "[Rank $i] vLLM 第 $attempt 次啟動失敗，正在終止程序..."
+            kill $VLLM_PID 2>/dev/null || true
+            wait $VLLM_PID 2>/dev/null || true
+
+            if [ $attempt -lt $MAX_VLLM_RETRIES ]; then
+                echo "[Rank $i] 等待 30 秒後重試..."
+                sleep 30
+            fi
+        done
+
+        if [ $VLLM_START_OK -eq 0 ]; then
+            echo "[Rank $i] vLLM 重試 ${MAX_VLLM_RETRIES} 次均失敗，取消整個 SLURM Job 以防止其他 rank 無效 hanging..."
+            # log already written under logs/vllm_test_rank${i}.log
+            echo "[Rank $i] vLLM 日誌保存在 logs/vllm_test_rank${i}.log"
+            scancel "${SLURM_JOB_ID}"
+            exit 1
+        fi
+
+        echo "[Rank $i] vLLM 伺服器已就緒。開始評測 (本機寫入)..."
+        uv run twinkle-eval --config "$LOCAL_CONFIG" --export json
+
+        kill $VLLM_PID
+        rm -f "$LOCAL_CONFIG"
+    ) &
+done
+
+wait
+rm -f $CONFIG_RUN
+
+# ==========================================
+# 5. 合併評測結果與上傳
+# ==========================================
+echo "等待檔案系統同步..."
+sleep 5
+
+# 直接使用本次 job 開始時統一設定的 RUN_TIMESTAMP，不再動態掃描。
+# 這避免了多個 rank subshell 在不同分鐘啟動時產生不同時間戳、導致合併遺漏的問題。
+if [ -n "${RUN_TIMESTAMP:-}" ]; then
+    # 清點實際寫出的 JSON shard 數是否符合預期 rank 數
+    # 單節點測試腳本：預期 INSTANCES_PER_NODE 個 shard（每個 rank 一個）
+    EXPECTED_SHARDS=${INSTANCES_PER_NODE}
+    # 同時支援兩種檔案格式：
+    #   多 rank： results_{ts}_node*_rank*.json  (world_size > 1)
+    #   單 rank： results_{ts}.json              (world_size = 1)
+    ACTUAL_SHARDS=$(find results/ -maxdepth 1 -name "results_${RUN_TIMESTAMP}_node*_rank*.json" 2>/dev/null | wc -l)
+    if [ "${ACTUAL_SHARDS}" -eq 0 ]; then
+        # 回落檢查單節點無後綴格式
+        if [ -f "results/results_${RUN_TIMESTAMP}.json" ]; then
+            ACTUAL_SHARDS=1
+        fi
+    fi
+
+    echo "=========================================="
+    echo "Shard 清點：預期 ${EXPECTED_SHARDS} 個，實際找到 ${ACTUAL_SHARDS} 個 (Timestamp: ${RUN_TIMESTAMP})"
+
+    if [ "${ACTUAL_SHARDS}" -eq 0 ]; then
+        echo "❌ 找不到任何 shard 檔案，可能所有 rank 均評測失敗，中止合併。"
+        exit 1
+    elif [ "${ACTUAL_SHARDS}" -lt "${EXPECTED_SHARDS}" ]; then
+        echo "⚠️  警告：僅收到 ${ACTUAL_SHARDS}/${EXPECTED_SHARDS} 個 shard，部分 rank 可能失敗，結果將不完整。"
+    else
+        echo "✅ Shard 數量符合預期，開始合併與上傳..."
+    fi
+
+    if [ -n "$HF_UPLOAD_REPO" ] && [ "$HF_UPLOAD_REPO" != "your-org/eval-logs" ]; then
+        uv run twinkle-eval --finalize-results "${RUN_TIMESTAMP}" --hf-repo-id "${HF_UPLOAD_REPO}" --hf-variant "${HF_VARIANT}"
+    else
+        uv run twinkle-eval --finalize-results "${RUN_TIMESTAMP}"
+    fi
+else
+    echo "⚠️ 找不到任何可供處理的評測結果，請確認評測是否已完成並寫入 results/ 目錄。"
+fi
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+echo "評測完成，共耗時 $DURATION 秒。"
+
+echo "校準總結:"
+echo "耗時: $DURATION 秒"
+echo "請使用此結果來調整 TP_SIZE 和 DP 節點數量，以確保總運行時間在您的限制範圍內。"

--- a/scripts/setup_vllm_venv.sh
+++ b/scripts/setup_vllm_venv.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# =============================================================================
+# setup_vllm_venv.sh  —  建立評估腳本所使用的 vLLM 虛擬環境。
+#
+# 用法：  bash scripts/setup_vllm_venv.sh
+#
+# 此虛擬環境將使用 uv + Python 3.12 建立於 <repo-root>/vllm-venv，
+# 並安裝包含 CUDA 附加套件的 vLLM。在提交任何 SLURM 評估任務前，請先執行此腳本一次。
+# =============================================================================
+
+set -euo pipefail
+
+WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VLLM_VENV="${WORK_DIR}/vllm-venv"
+
+# 確保可使用使用者本機二進位檔 (uv)
+export PATH="$HOME/.local/bin:$HOME/miniconda3/bin:$HOME/miniconda3/condabin:$PATH"
+
+# 如果尚未安裝 uv，則進行安裝
+if ! command -v uv &>/dev/null; then
+    echo "[設定] 找不到 uv — 正在透過 pip 安裝 ..."
+    pip install --user uv
+fi
+
+echo "[設定] 正在 ${VLLM_VENV} 建立 vllm-venv (Python 3.12) ..."
+uv venv --python 3.12 "${VLLM_VENV}"
+
+echo "[設定] 正在安裝 vLLM (這可能需要幾分鐘) ..."
+uv pip install --python "${VLLM_VENV}" vllm
+
+echo "[設定] 正在驗證安裝 ..."
+"${VLLM_VENV}/bin/python" -c "import vllm; print(f'  vLLM {vllm.__version__} 正常')"
+"${VLLM_VENV}/bin/python" -c "import torch;  print(f'  PyTorch {torch.__version__} 正常')"
+"${VLLM_VENV}/bin/python" -c "import ray;    print(f'  Ray {ray.__version__} 正常')"
+
+echo "[設定] 完成。vllm-venv 已在 ${VLLM_VENV} 準備就緒"

--- a/twinkle_eval/__init__.py
+++ b/twinkle_eval/__init__.py
@@ -23,7 +23,7 @@
 授權：MIT License
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __author__ = "Twinkle AI Team"
 __license__ = "MIT"
 

--- a/twinkle_eval/config.py
+++ b/twinkle_eval/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict
 
 import yaml
@@ -109,6 +110,17 @@ class ConfigurationManager:
         for key, value in eval_defaults.items():
             if key not in self.config["evaluation"]:
                 self.config["evaluation"][key] = value
+
+        # 設定分散式評測預設值（從環境變數讀取，單機時保持 rank=0, world_size=1）
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        rank = int(os.environ.get("RANK", "0"))
+        dist_defaults = {"world_size": world_size, "rank": rank}
+        if "distributed" not in self.config:
+            self.config["distributed"] = dist_defaults
+        else:
+            for key, value in dist_defaults.items():
+                if key not in self.config["distributed"]:
+                    self.config["distributed"][key] = value
 
         # 設定預設環境配置
         if "environment" not in self.config:

--- a/twinkle_eval/dataset.py
+++ b/twinkle_eval/dataset.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import string
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -18,6 +19,66 @@ from datasets import get_dataset_config_names, get_dataset_split_names, load_dat
 from .logger import log_error, log_info, log_warning
 
 
+def _index_to_label(idx: int) -> str:
+    """將 0-based 索引轉換為 Excel 風格的大寫字母標籤（A…Z、AA…AZ、BA…）。"""
+    letters = []
+    while True:
+        idx, rem = divmod(idx, 26)
+        letters.append(string.ascii_uppercase[rem])
+        if idx == 0:
+            break
+        idx -= 1
+    return "".join(reversed(letters))
+
+
+def _normalize_record(record: dict) -> dict:
+    """將 choices-list 格式正規化為具名字母鍵格式。
+
+    支援兩種輸入格式：
+    1. 整數索引 answer（MMLU HuggingFace 格式）：
+       {"question": "...", "choices": [...], "answer": 1}
+       → {"question": "...", "A": "opt0", "B": "opt1", ..., "answer": "B"}
+    2. 字母 answer（choices 仍為 list 但 answer 已是字母）：
+       {"question": "...", "choices": [...], "answer": "B"}
+       → {"question": "...", "A": "opt0", ..., "answer": "B"}
+
+    若 record 已是具名字母鍵格式則直接回傳（向下相容）。
+    """
+    choices = record.get("choices")
+    answer = record.get("answer")
+
+    if not (
+        hasattr(choices, "__iter__")
+        and not isinstance(choices, (str, bytes, dict))
+        and len(choices) >= 2
+    ):
+        return record
+
+    choices = list(choices)
+    labels = [_index_to_label(i) for i in range(len(choices))]
+
+    try:
+        idx = int(answer)
+    except (TypeError, ValueError):
+        idx = None
+
+    if idx is not None:
+        if not (0 <= idx < len(choices)):
+            return record
+        answer_letter = labels[idx]
+    else:
+        answer_str = str(answer).strip().upper()
+        if answer_str not in labels:
+            return record
+        answer_letter = answer_str
+
+    normalized = {k: v for k, v in record.items() if k not in ("choices", "answer")}
+    for label, text in zip(labels, choices):
+        normalized[label] = text
+    normalized["answer"] = answer_letter
+    return normalized
+
+
 class Dataset:
     """資料集類別 - 負責載入和管理單一資料集檔案
 
@@ -27,15 +88,21 @@ class Dataset:
     - Parquet: Apache Parquet 格式
     - Arrow: Apache Arrow 格式
     - CSV/TSV: 逗號或制表符分隔的文字檔
+
+    自動將 MMLU HuggingFace 格式（choices + 整數 answer）正規化為 A/B/C/D 格式。
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, node_id: Optional[str] = None, rank: Optional[int] = None):
         """初始化資料集
 
         Args:
             file_path: 資料集檔案路徑
+            node_id: SLURM 節點 ID（分散式評測用，可選）
+            rank: 分散式 rank（可選）
         """
         self.file_path = file_path
+        self.node_id = node_id
+        self.rank = rank
         self.data = self._load_data()
 
     def _load_data(self):
@@ -76,7 +143,12 @@ class Dataset:
             else:
                 raise ValueError(f"不支援的檔案格式: {ext}")
 
-            log_info(f"成功讀取檔案: {self.file_path}，共 {len(data)} 題")
+            # 正規化：將 choices-list + 整數 answer 格式轉為 A/B/C/D 具名欄位格式
+            data = [_normalize_record(r) for r in data]
+            if self.node_id is not None and self.rank is not None:
+                log_info(f"[節點 {self.node_id} | Rank {self.rank}] 成功讀取: {self.file_path}，共 {len(data)} 題")
+            else:
+                log_info(f"成功讀取檔案: {self.file_path}，共 {len(data)} 題")
             return data
         except Exception as e:
             log_error(f"讀取資料錯誤: {e}")

--- a/twinkle_eval/evaluators.py
+++ b/twinkle_eval/evaluators.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import re
+import socket
 import time
 from math import comb
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -13,6 +14,12 @@ from .dataset import Dataset
 from .evaluation_strategies import EvaluationStrategy
 from .logger import log_error
 from .models import LLM
+
+
+def _get_node_id() -> str:
+    """取得當前節點識別碼，優先使用 SLURM_NODEID，否則回退至 node0。"""
+    slurm_node = os.environ.get("SLURM_NODEID")
+    return slurm_node if slurm_node is not None else "0"
 
 
 _THINK_TAG_PAIRS = [
@@ -223,7 +230,15 @@ class Evaluator:
 
         results_dir = "results"
         os.makedirs(results_dir, exist_ok=True)
-        results_path = os.path.join(results_dir, f"eval_results_{timestamp}.jsonl")
+
+        # 分散式模式下，每個節點/rank 寫入獨立的 shard 檔案，避免並行寫入衝突
+        node_id = _get_node_id()
+        rank = self.model_overrides.get("_rank", 0)  # 由 main.py 透過 model_overrides 傳入
+        if node_id != "0" or rank != 0:
+            shard_suffix = f"_node{node_id}_rank{rank}"
+        else:
+            shard_suffix = ""
+        results_path = os.path.join(results_dir, f"eval_results_{timestamp}{shard_suffix}.jsonl")
 
         # 將每個 detail 項目寫入 JSONL 檔案（使用 'a' 避免多檔評測時覆蓋先前結果）
         with open(results_path, "a", encoding="utf-8") as f:

--- a/twinkle_eval/finalize.py
+++ b/twinkle_eval/finalize.py
@@ -1,0 +1,225 @@
+import glob
+import json
+import os
+from collections import defaultdict
+from typing import Optional
+
+import numpy as np
+
+from .results_exporters import ResultsExporterFactory
+
+
+def finalize_results(timestamp: str, hf_repo_id: Optional[str] = None, hf_variant: Optional[str] = "default") -> int:
+    """合併平行運算產生的碎片並重新計算評測指標，最後刪除碎片。
+    若無碎片但存在單節點最終結果，則直接執行上傳。
+    """
+
+    results_dir = "results"
+    json_shards = sorted(glob.glob(os.path.join(results_dir, f"results_{timestamp}_node*_rank*.json")))
+
+    if not json_shards:
+        # 單節點執行：直接上傳已存在的最終結果，無須合併
+        single_node_result = os.path.join(results_dir, f"results_{timestamp}.json")
+        if not os.path.exists(single_node_result):
+            print(f"找不到時間戳記為 {timestamp} 的評測碎片或最終結果。")
+            return 1
+
+        print(f"未發現分散式碎片，以單節點模式直接上傳 {single_node_result}。")
+        if hf_repo_id:
+            try:
+                from .hf_uploader import upload_results
+                with open(single_node_result, "r", encoding="utf-8") as _f:
+                    _result = json.load(_f)
+                model_name = _result.get("config", {}).get("model", {}).get("name", "unknown_model")
+                upload_results(
+                    repo_id=hf_repo_id,
+                    variant=hf_variant,
+                    model_name=model_name,
+                    results_dir=results_dir,
+                    timestamp=timestamp,
+                )
+                print("上傳完成。")
+            except Exception as e:
+                print(f"上傳至 Hugging Face 失敗: {e}")
+                return 1
+        return 0
+
+    print(f"找到 {len(json_shards)} 個 JSON 配置碎片。開始合併與統整數據...")
+
+    with open(json_shards[0], "r", encoding="utf-8") as f:
+        base_result = json.load(f)
+
+    # ── 第一階段：收集元資料 ────────────────────────────────────────────────
+    # run_idx -> 屬於該 run 的所有分片 JSONL 路徑列表
+    run_jsonl_shards: dict[int, list[str]] = defaultdict(list)
+    # ds_name -> file_path -> 該檔案包含的 run_idx 集合
+    ds_file_runs: dict[str, dict[str, set[int]]] = defaultdict(lambda: defaultdict(set))
+
+    for shard_path in json_shards:
+        with open(shard_path, "r", encoding="utf-8") as f:
+            shard_data = json.load(f)
+
+        for ds_name, ds_data in shard_data.get("dataset_results", {}).items():
+            for file_res in ds_data.get("results", []):
+                file_path = file_res["file"]
+                jsonl_paths = file_res.get("individual_runs", {}).get("results", [])
+                for run_idx, jsonl_path in enumerate(jsonl_paths):
+                    ds_file_runs[ds_name][file_path].add(run_idx)
+                    if jsonl_path not in run_jsonl_shards[run_idx]:
+                        run_jsonl_shards[run_idx].append(jsonl_path)
+
+    # ── 第二階段：串流合併所有分片 JSONL → 每個 run 產生一個合併後的 JSONL ─
+    # run_idx -> 合併後的 JSONL 路徑
+    run_merged_path: dict[int, str] = {}
+    merged_jsonl_files: list[str] = []
+    shard_jsonl_files: set[str] = set()  # 待清理的原始分片 JSONL
+
+    try:
+        for run_idx, shard_paths in sorted(run_jsonl_shards.items()):
+            merged_name = os.path.join(results_dir, f"eval_results_{timestamp}_run{run_idx}.jsonl")
+            run_merged_path[run_idx] = merged_name
+            merged_jsonl_files.append(merged_name)
+
+            # 從此 run 的每個分片蒐集所有記錄
+            all_entries: list[dict] = []
+            for j_path in shard_paths:
+                if os.path.exists(j_path):
+                    shard_jsonl_files.add(j_path)
+                    with open(j_path, "r", encoding="utf-8") as jf:
+                        for line in jf:
+                            line = line.strip()
+                            if line:
+                                all_entries.append(json.loads(line))
+
+            # 依 question_id 排序後一次寫入，避免反覆開檔
+            all_entries.sort(key=lambda x: int(x.get("question_id", 0)))
+            print(f"  run{run_idx}: 合併 {len(shard_paths)} 個碎片 → {len(all_entries)} 筆記錄")
+
+            with open(merged_name, "w", encoding="utf-8") as jf:
+                for entry in all_entries:
+                    jf.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+        # ── 第三階段：掃描合併後的 JSONL，依來源檔案統計正確率 ──────────────
+        # run_idx -> file_path -> 是否正確的布林串列
+        run_file_correct: dict[int, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+
+        for run_idx, merged_path in run_merged_path.items():
+            if not os.path.exists(merged_path):
+                continue
+            with open(merged_path, "r", encoding="utf-8") as jf:
+                for line in jf:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    entry = json.loads(line)
+                    # 優先使用 source_file，其次嘗試 file 欄位
+                    src_file = entry.get("source_file") or entry.get("file")
+                    if src_file:
+                        run_file_correct[run_idx][src_file].append(entry.get("is_correct", False))
+
+        # ── 第四階段：組裝最終結果結構 ────────────────────────────────────────
+        merged_dataset_results: dict = {}
+
+        for ds_name, files_map in ds_file_runs.items():
+            ds_results = []
+            for file_path, run_indices in files_map.items():
+                run_accuracies = []
+                run_merged_jsonl_paths = []
+
+                for run_idx in sorted(run_indices):
+                    merged_path = run_merged_path.get(run_idx)
+                    if merged_path:
+                        run_merged_jsonl_paths.append(merged_path)
+
+                    # 優先從第三階段的統計結果取得正確率
+                    correct_list = run_file_correct.get(run_idx, {}).get(file_path)
+                    if correct_list is not None:
+                        acc = sum(correct_list) / len(correct_list) if correct_list else 0.0
+                    else:
+                        # 備援：直接從原始分片 JSON 讀取預先計算的正確率
+                        acc = _acc_from_shards(json_shards, ds_name, file_path, run_idx)
+                    run_accuracies.append(acc)
+
+                mean_acc = float(np.mean(run_accuracies)) if run_accuracies else 0.0
+                std_acc = float(np.std(run_accuracies)) if len(run_accuracies) > 1 else 0.0
+
+                ds_results.append({
+                    "file": file_path,
+                    "accuracy_mean": mean_acc,
+                    "accuracy_std": std_acc,
+                    "individual_runs": {
+                        "accuracies": run_accuracies,
+                        "results": run_merged_jsonl_paths,
+                    },
+                })
+
+            ds_avg_acc = float(np.mean([r["accuracy_mean"] for r in ds_results])) if ds_results else 0.0
+            ds_avg_std = float(np.mean([r["accuracy_std"] for r in ds_results])) if ds_results else 0.0
+
+            merged_dataset_results[ds_name] = {
+                "results": ds_results,
+                "average_accuracy": ds_avg_acc,
+                "average_std": ds_avg_std,
+            }
+
+        final_results = {
+            "timestamp": timestamp,
+            "config": base_result["config"],
+            "duration_seconds": base_result.get("duration_seconds", 0),
+            "dataset_results": merged_dataset_results,
+        }
+
+        base_output_path = os.path.join(results_dir, f"results_{timestamp}")
+        exported_files = ResultsExporterFactory.export_results(
+            final_results, base_output_path, ["json"], base_result["config"]
+        )
+        print(f"✅ 合併完成，結果已匯出至: {', '.join(exported_files)}")
+
+    finally:
+        # ── 清理：即使程式中途被中斷或記憶體不足也保證執行 ────────────────────
+        print("🧹 清理 Rank 分散式碎片...")
+        for sp in json_shards:
+            try:
+                os.remove(sp)
+            except OSError:
+                pass
+        for jp in shard_jsonl_files:
+            try:
+                os.remove(jp)
+            except OSError:
+                pass
+
+    if hf_repo_id:
+        try:
+            from .hf_uploader import upload_results
+            model_name = base_result["config"].get("model", {}).get("name", "unknown_model")
+            upload_results(
+                repo_id=hf_repo_id,
+                variant=hf_variant,
+                model_name=model_name,
+                results_dir=results_dir,
+                timestamp=timestamp,
+            )
+            print("✅ 成功上傳合併結果至 Hugging Face")
+        except Exception as e:
+            print(f"❌ 上傳至 Hugging Face 失敗: {e}")
+
+    return 0
+
+
+def _acc_from_shards(json_shards: list[str], ds_name: str, file_path: str, run_idx: int) -> float:
+    """備援函式：直接從各分片 JSON 讀取已預先計算的正確率（當 JSONL 內無來源檔案欄位時使用）"""
+    accs = []
+    for sp in json_shards:
+        with open(sp, "r", encoding="utf-8") as f:
+            shard = json.load(f)
+        for fr in shard.get("dataset_results", {}).get(ds_name, {}).get("results", []):
+            if fr["file"] == file_path:
+                run_accs = fr.get("individual_runs", {}).get("accuracies", [])
+                if run_idx < len(run_accs):
+                    accs.append(run_accs[run_idx])
+    return float(np.mean(accs)) if accs else 0.0
+
+
+# 向後相容別名
+merge_distributed_results = finalize_results

--- a/twinkle_eval/hf_uploader.py
+++ b/twinkle_eval/hf_uploader.py
@@ -1,0 +1,124 @@
+"""Hugging Face 資料集上傳服務
+
+需要安裝 slurm extra：pip install twinkle-eval[slurm]
+"""
+
+import glob
+import os
+from typing import Optional
+
+from .logger import log_error, log_info
+
+try:
+    from huggingface_hub import HfApi, HfFileSystem
+    from huggingface_hub.utils import RepositoryNotFoundError
+except ImportError:
+    raise ImportError(
+        "HuggingFace 上傳功能需要安裝額外套件，請執行：\n"
+        "  pip install twinkle-eval[slurm]"
+    )
+
+
+def validate_repo_id(repo_id: str) -> None:
+    """驗證 Hugging Face repo ID 格式，若不存在則自動創建"""
+    # 檢查格式 <namespace>/<name>
+    if "/" not in repo_id or len(repo_id.split("/")) != 2:
+        raise ValueError(f"無效的 repo ID 格式: {repo_id}。必須為 <namespace>/<name>")
+    
+    # 檢查結尾
+    if not repo_id.endswith("-logs-and-scores"):
+        raise ValueError(f"Repo 名稱必須以 '-logs-and-scores' 結尾: {repo_id}")
+
+    # 使用 HfApi 檢查存在性並確認為 dataset
+    api = HfApi()
+    try:
+        # 若 repo 不是 dataset 或不存在，將在此拋出例外
+        api.dataset_info(repo_id=repo_id)
+        log_info(f"Dataset repo {repo_id} 已存在")
+    except RepositoryNotFoundError:
+        # Repo 不存在，自動創建以提升 UX
+        log_info(f"Dataset repo {repo_id} 不存在，正在創建...")
+        try:
+            api.create_repo(
+                repo_id=repo_id,
+                repo_type="dataset",
+                private=False,
+            )
+            log_info(f"成功創建 Dataset repo: {repo_id}")
+        except Exception as create_error:
+            raise ValueError(f"創建 Dataset repo 失敗 {repo_id}: {create_error}")
+    except Exception as e:
+        # 例如: 認證錯誤
+        raise ValueError(f"檢查 repo 時發生錯誤 {repo_id}: {e}")
+
+
+def upload_results(
+    repo_id: str,
+    variant: Optional[str],
+    model_name: str,
+    results_dir: str,
+    timestamp: str,
+) -> None:
+    """上傳評測結果至 Hugging Face dataset repo"""
+    
+    # 驗證 repo_id
+    validate_repo_id(repo_id)
+    
+    # 識別要上傳的檔案
+    
+    files_to_upload = []
+    
+    # 主要結果檔案
+    results_json = os.path.join(results_dir, f"results_{timestamp}.json")
+    if os.path.exists(results_json):
+        files_to_upload.append(results_json)
+    
+    # Run 檔案
+    run_files = glob.glob(os.path.join(results_dir, f"eval_results_{timestamp}_run*.jsonl"))
+    files_to_upload.extend(run_files)
+    
+    if not files_to_upload:
+        log_info("本次執行未找到可上傳的檔案。")
+        return
+
+    # 決定上傳路徑
+    # results/<model>/<variant>/
+    variant_path = variant if variant else "default"
+    # 確保 variant 安全：移除路徑分隔符、父目錄引用及前後空白
+    variant_path = variant_path.strip().replace("/", "_").replace("\\", "_").replace("..", "_")
+    #確保 model name 安全
+    safe_model_name = model_name.replace("/", "__") 
+    target_dir = f"results/{safe_model_name}/{variant_path}"
+    
+    api = HfApi()
+    
+    log_info(f"正在上傳 {len(files_to_upload)} 個檔案至 {repo_id}/{target_dir}...")
+    
+    try:
+        fs = HfFileSystem()
+        for file_path in files_to_upload:
+            file_name = os.path.basename(file_path)
+            path_in_repo = f"{target_dir}/{file_name}"
+            
+            # 檢查檔案是否存在以防止覆蓋
+            # 需求: "既有 repo 檔案不得覆蓋"
+            if fs.exists(f"datasets/{repo_id}/{path_in_repo}"):
+                log_error(f"檔案 {path_in_repo} 已存在於 repo 中。跳過以防止覆蓋。")
+                continue
+
+            print(f"正在上傳 {file_name}...")
+            api.upload_file(
+                path_or_fileobj=file_path,
+                path_in_repo=path_in_repo,
+                repo_id=repo_id,
+                repo_type="dataset",
+                commit_message=f"Upload evaluation results for {model_name} ({timestamp})"
+            )
+            
+        dataset_url = f"https://huggingface.co/datasets/{repo_id}/tree/main/{target_dir}"
+        log_info(f"上傳完成。Dataset URL: {dataset_url}")
+        print(f"✅ 上傳成功！查看網址: {dataset_url}")
+        
+    except Exception as e:
+        log_error(f"上傳至 Hugging Face 失敗: {e}")
+        raise

--- a/twinkle_eval/main.py
+++ b/twinkle_eval/main.py
@@ -563,6 +563,29 @@ HuggingFace 資料集下載:
         help="將 JSON 結果檔案轉換為 HTML 格式",
     )
 
+    parser.add_argument(
+        "--finalize-results",
+        metavar="TIMESTAMP",
+        help=(
+            "後處理指定時間戳記的評測結果：若找到分散式碎片則自動合併，"
+            "若為單節點最終結果則直接上傳 (可搭配 --hf-repo-id)"
+        ),
+    )
+
+    # HuggingFace 上傳參數
+    parser.add_argument(
+        "--hf-repo-id",
+        help=(
+            "Hugging Face dataset repo ID，用於上傳結果 "
+            "(格式: namespace/repo-name，repo-name 必須以 -logs-and-scores 結尾)"
+        ),
+    )
+
+    parser.add_argument(
+        "--hf-variant",
+        help="結果變體名稱（例如: low, medium, high），用於區分不同評測條件",
+    )
+
     # Benchmark 相關命令
     parser.add_argument(
         "--benchmark",
@@ -692,6 +715,19 @@ def main() -> int:
             return convert_json_to_html(args.convert_to_html)
         except Exception as e:
             print(f"❌ 轉換失敗: {e}")
+            return 1
+
+    # 分散式結果合併與 HuggingFace 上傳
+    if args.finalize_results:
+        try:
+            from .finalize import finalize_results
+            return finalize_results(
+                args.finalize_results,
+                getattr(args, "hf_repo_id", None),
+                getattr(args, "hf_variant", None),
+            )
+        except Exception as e:
+            print(f"❌ 合併結果失敗: {e}")
             return 1
 
     # Benchmark 命令


### PR DESCRIPTION
## Summary

- **Slurm 多節點分散式評測**：每個節點/rank 輸出獨立 shard JSONL，避免並行寫入衝突；`WORLD_SIZE`/`RANK` 環境變數自動讀取
- **`--finalize-results <timestamp>`**：自動合併分散式碎片、重新計算指標，產出最終 `results_{timestamp}.json`
- **`--hf-repo-id` / `--hf-variant`**：評測完成或 finalize 後自動上傳至 HuggingFace Dataset repo
- **`pip install twinkle-eval[slurm]`**：`huggingface-hub` 改為 optional extras，不影響現有使用者
- **dataset.py**：自動正規化 MMLU HuggingFace 格式（`choices` list + 整數 `answer`）為 A/B/C/D 具名欄位，支援超過 4 個選項
- 新增 `scripts/`（可直接 sbatch 的 Slurm 腳本）、`configs/`（範例設定）、`SLURM_README.md`

## 與 PR #19 的差異

- ✅ 保留 1.1.x–1.2.0 的所有修正（think-tag、reasoning_content、pass@k 等）
- ✅ `huggingface-hub` 改為 optional（`pip install twinkle-eval[slurm]`）
- ✅ 未安裝時呼叫 HF 上傳功能會拋出清楚的 `ImportError`
- ✅ 47 個現有測試全過，無 regression

## Credits

原始設計：@whats2000（PR #19）

## Test plan

- [ ] `pytest tests/` — 47 個測試全過
- [ ] 單機執行路徑不受影響（不設定 `WORLD_SIZE`/`RANK`）
- [ ] `pip install twinkle-eval` 不安裝 `huggingface-hub`，但使用 `--hf-repo-id` 時有清楚提示
- [ ] `pip install twinkle-eval[slurm]` 後 `--hf-repo-id` 正常運作

## Closes

Supersedes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)