### PR TITLE
Fix NIAH exact scoring for LongBench paragraph labels

### DIFF
--- a/tests/test_niah.py
+++ b/tests/test_niah.py
@@ -9,6 +9,7 @@ import pytest
 from twinkle_eval.metrics.extractors.niah import NIAHExtractor
 from twinkle_eval.metrics.scorers.niah import (
     NIAHScorer,
+    _normalize_reference_label,
     _normalize_text,
     _tokenize_chinese,
     compute_f1,
@@ -136,6 +137,14 @@ class TestNIAHScorer:
     def test_exact_mode_false(self):
         scorer = NIAHScorer({"niah_scoring_mode": "exact"})
         assert scorer.score("42 billion dollars", "42 billion") is False
+
+    def test_exact_mode_paragraph_spacing_true(self):
+        scorer = NIAHScorer({"niah_scoring_mode": "exact"})
+        assert scorer.score("段落 9", "段落9") is True
+
+    def test_normalize_reference_label_paragraph_spacing(self):
+        assert _normalize_reference_label("段落 27") == "段落27"
+        assert _normalize_reference_label("paragraph 12") == "paragraph12"
 
     def test_f1_mode_above_threshold(self):
         scorer = NIAHScorer({"niah_scoring_mode": "f1", "niah_f1_threshold": 0.5})

--- a/twinkle_eval/metrics/scorers/niah.py
+++ b/twinkle_eval/metrics/scorers/niah.py
@@ -23,6 +23,14 @@ def _normalize_text(text: str) -> str:
     return text
 
 
+def _normalize_reference_label(text: str) -> str:
+    """正規化段落/編號標籤，避免 `段落9` 與 `段落 9` 類型差異造成誤判。"""
+    text = _normalize_text(text)
+    text = re.sub(r"(段落)\s+(\d+)", r"\1\2", text)
+    text = re.sub(r"(paragraph)\s+(\d+)", r"\1\2", text)
+    return text
+
+
 def _tokenize_chinese(text: str) -> list[str]:
     """簡易中文分詞：逐字拆分中文字元，英文按空白分詞。"""
     tokens: list[str] = []
@@ -97,7 +105,7 @@ class NIAHScorer(Scorer):
         gold_str = str(gold)
 
         if self.scoring_mode == "exact":
-            return _normalize_text(pred_str) == _normalize_text(gold_str)
+            return _normalize_reference_label(pred_str) == _normalize_reference_label(gold_str)
         elif self.scoring_mode == "f1":
             return compute_f1(pred_str, gold_str) >= self.f1_threshold
         else:


### PR DESCRIPTION
  ## Summary
  Fix NIAH exact scoring for LongBench-style paragraph labels by normalizing spacing between the label and the numeric index.

  ## Problem
  LongBench answers such as `段落9` were being marked incorrect when the model responded with `段落 9`, even in `niah_scoring_mode:
  exact`.

  ## Changes
  - add `_normalize_reference_label()` in `twinkle_eval/metrics/scorers/niah.py`
  - normalize `段落 9` -> `段落9`
  - normalize `paragraph 12` -> `paragraph12`
  - apply this normalization in NIAH `exact` mode
  - add regression tests for paragraph-label spacing

  ## Validation
  ```bash
  pytest tests/test_niah.py