### PR TITLE
feat(bench): 新增 Formosa-bench 評測集

### DIFF
--- a/configs/config_slurm_full.yaml
+++ b/configs/config_slurm_full.yaml
@@ -22,6 +22,7 @@ evaluation:
     - "PLACEHOLDER_DATASET_DIR/ikala__tmmluplus/"
     - "PLACEHOLDER_DATASET_DIR/cais__mmlu/"
     - "PLACEHOLDER_DATASET_DIR/lianghsun__tw-legal-benchmark-v1/"
+    - "PLACEHOLDER_DATASET_DIR/lianghsun__Formosa-bench/"
   evaluation_method: "box"
   system_prompt:
     zh: |

--- a/scripts/run_slurm_full.sh
+++ b/scripts/run_slurm_full.sh
@@ -144,6 +144,13 @@ if [[ ! -d "${DATASET_DIR}/cais__mmlu" ]]; then
         --dataset-split test \
         --output-dir "${DATASET_DIR}"
 fi
+
+if [[ ! -d "${DATASET_DIR}/lianghsun__Formosa-bench" ]]; then
+    echo "正在下載 Formosa-bench (train) ..."
+    uv run twinkle-eval --download-dataset lianghsun/Formosa-bench \
+        --dataset-split train \
+        --output-dir "${DATASET_DIR}"
+fi
 # ==============================================================================
 
 # 建立動態配置檔


### PR DESCRIPTION
## 摘要

- 將 `lianghsun/Formosa-bench` 新增至 SLURM 完整評測的預設評測集清單
- 新增自動下載 Formosa-bench 資料集的腳本邏輯

## 變更內容

- `configs/config_slurm_full.yaml`：在 `dataset_paths` 中新增 `lianghsun__Formosa-bench`
- `scripts/run_slurm_full.sh`：新增 Formosa-bench 資料集下載區塊（使用 `train` split）

## 測試計畫

- [ ] 確認 `lianghsun/Formosa-bench` 資料集可正常下載
- [ ] 驗證 SLURM 完整評測流程可正常執行