### PR TITLE
docs(skills): 新增 /run-eval 與 /add-benchmark 兩個 Claude Code skill

### DIFF
--- a/.claude/skills/add-benchmark/SKILL.md
+++ b/.claude/skills/add-benchmark/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: add-benchmark
+description: 為 Twinkle Eval 新增一個評測 benchmark（IFEval、BFCL、RAGAS、Text2SQL、Vision MCQ 之類）。涵蓋 CLAUDE.md §6 的完整強制流程：先建 Milestone 與 6 個 Issue、準備 example dataset、實作 Extractor + Scorer 並註冊 PRESETS、與參考框架做分數與速度對比、撰寫 docs/evals/{name}.md、更新 datasets/example/README.md、建立 tests/test_{name}.py。當使用者說「新增 benchmark」「加一個評測方法」「支援 XXX 評測」「實作 evaluation_method」時使用。
+---
+
+# 新增評測 Benchmark
+
+CLAUDE.md §6 規定的流程，**缺一步就不得合入 main**。這份 skill 是那份規範的可執行版本。
+
+## 動手前先確認
+
+- [ ] 這是**新的評測方法**（新的 Extractor/Scorer 配對），不是既有方法的新資料集。
+      若只是新資料集且能沿用既有 `evaluation_method`，走 `twinkle_eval/benchmarks.py`
+      的下載註冊表即可，不需要跑本流程。
+- [ ] 上一個 benchmark 已經完成（含比較報告）。§6.0.1 明訂：**先完成再開始下一個**。
+
+## 第 0 步：先開 GitHub，再寫程式
+
+**沒有 Milestone 和 Issues 的 benchmark 實作不得開 PR。**
+
+```bash
+gh api repos/ai-twinkle/Eval/milestones -f title="{Benchmark} — {一句話說明}" \
+  -f description="來源：{paper/repo}｜目的：{評什麼}｜範圍：{預計實作到哪}"
+```
+
+接著開 6 個 Issue，每個都要掛 `type: feature` label 與該 Milestone：
+
+| # | 標題格式 | 對應 |
+|---|---------|------|
+| 1 | `feat({name}): prepare example dataset from HuggingFace` | §6.1 |
+| 2 | `feat({name}): implement Extractor + Scorer (+ Checkers)` | §6.2 |
+| 3 | `feat({name}): score comparison vs reference framework` | §6.3 |
+| 4 | `feat({name}): speed benchmark vs reference framework` | §6.4 |
+| 5 | `feat({name}): write docs/evals/{name}.md` | §6.5 |
+| 6 | `feat({name}): write tests/test_{name}.py` | §6.6 |
+
+```bash
+gh issue create --title "feat({name}): ..." --label "type: feature" --milestone "{Milestone 標題}"
+```
+
+## 第 1 步：example dataset
+
+放在 `datasets/example/{name}/`，**10–20 筆**（§6.1 規範；既有資料集實際落在 10–30 筆，如 aime2025 收了全部 30 題），涵蓋主要題型分佈。有子類別的（如 BFCL 的
+simple/multiple/parallel）每個子類別至少 2–3 筆。
+
+要求任何人**不下載完整資料集**就能跑通完整流程。格式必須是可直接執行的完整格式
+（含 `id`、`question`、答案欄位）。
+
+`scripts/` 底下有既有的抽取腳本可以參考（`prepare_bbh_example.py`、
+`create_vision_mcq_example.py`）。
+
+資料集載入器支援 JSON / JSONL / CSV / TSV / Parquet / Arrow。`twinkle_eval/datasets/file.py` 的
+`_normalize_record()` 會自動把 `{"choices": [...], "answer": 1}` 這種 HuggingFace 格式
+正規化成 `{"A": ..., "B": ..., "answer": "B"}`。
+
+## 第 2 步：實作 Extractor + Scorer
+
+架構是 **Extractor（從輸出抽答案）+ Scorer（比對正解）** 兩個 ABC，定義在
+`twinkle_eval/core/abc.py`。**不要**在 `evaluators.py` / `main.py` 加 `if/elif` 分支（原則 A）。
+
+```python
+# twinkle_eval/metrics/extractors/{name}.py
+from typing import Optional
+
+from twinkle_eval.core.abc import Extractor
+
+
+class MyExtractor(Extractor):
+    def get_name(self) -> str:
+        return "{name}"
+
+    def extract(self, llm_output: str) -> Optional[str]:
+        """抽不到回傳 None（會被計入 unparsed_count）。"""
+        ...
+```
+
+```python
+# twinkle_eval/metrics/scorers/{name}.py
+from twinkle_eval.core.abc import Scorer
+
+
+class MyScorer(Scorer):
+    def get_name(self) -> str:
+        return "{name}"
+
+    def normalize(self, answer: str) -> str:
+        return answer.strip().upper()
+
+    def score(self, predicted: str, gold: str) -> bool:
+        ...
+```
+
+註冊到 `twinkle_eval/metrics/__init__.py` 的 `PRESETS`：
+
+```python
+PRESETS: Dict[str, Tuple[Type[Extractor], Type[Scorer]]] = {
+    ...
+    "{name}": (MyExtractor, MyScorer),
+}
+```
+
+同時把類別加進該檔案的 `__all__`，並視需要加進 `twinkle_eval/__init__.py`。
+
+### Evaluator 需要新的資料流嗎？
+
+`runners/evaluator.py` 的 `evaluate_file()` 依 extractor 上的 flag 分流。若你的 benchmark
+不是「送文字、收文字」，設對應的 class attribute：
+
+| Flag | 路徑 | 既有使用者 |
+|------|------|-----------|
+| `uses_logprobs` | 逐選項算 log-likelihood，不生成 | logit |
+| `uses_tool_calls` | 送 `tools`，讀 `message.tool_calls` | bfcl_fc |
+| `uses_prompt_injection` | 把 function 定義注入 system prompt | bfcl_prompt |
+| `uses_ifeval` | 傳 `instruction_id_list` + `kwargs` 給 checker | ifeval, ifbench |
+| `uses_audio` | 送音檔（Whisper API 或多模態） | asr |
+| `uses_vision` | 送圖片（base64 data URI 或 URL） | vision_mcq |
+| （無） | 純文字解析 | pattern, box, math, ... |
+
+新增第 8 條路徑等於「在核心流程新增大量邏輯」，依 §7 必須**先開 Issue 取得 maintainer 同意**。
+先確認能不能用既有路徑。
+
+### 需要多指標（不只 accuracy）？
+
+在 Scorer 上實作 `score_full()` 回傳 dict（IFEval 的四個指標、ASR 的 WER/CER 都是這樣做）。
+
+⚠️ **但 evaluator 目前只在 `uses_ifeval` 與 `uses_audio` 兩條路徑呼叫 `score_full()`。**
+文字、logit、tool_calls、prompt_injection、vision 五條路徑不會呼叫，在那些路徑上實作了也不會生效。
+若新 benchmark 需要多指標又不走這兩條路徑，得先在 evaluator 加上呼叫點——那屬於
+「在核心流程新增邏輯」，依 §7 要先開 Issue。
+
+### 移植第三方程式碼
+
+- **不得**整份複製參考框架，只萃取核心評分邏輯
+- Python 檔案頂部加 attribution 註解，`docs/evals/{name}.md` 記錄授權（Apache 2.0 / MIT）
+- 原始碼用到不可用的依賴（`absl`、`immutabledict`）必須換成標準庫等價物
+- 新依賴一律放 `pyproject.toml` 的 `[project.optional-dependencies]`。
+  新增 **required** dependency 依 §7 必須**先開 Issue 並取得 maintainer 同意**，
+  且不得讓單機執行路徑增加必要依賴（原則 H）
+
+## 第 3 步：config 範本
+
+`twinkle_eval/templates/{name}.yaml`。`--init` 會自動掃描這個目錄，不需要改程式碼。
+
+範本必須含 `llm_api` / `model` / `evaluation` / `logging` 四個區塊，並在註解裡寫清楚
+optional deps 的安裝指令與資料集欄位需求。參考 `templates/ifeval.yaml`。
+
+若有 `strategy_config` 參數，在範本裡列出全部並附預設值。
+
+## 第 4 步：分數對比（§6.3）
+
+用**相同模型、相同題目**同時跑本專案與參考框架。
+
+| 資料集大小 | 可接受誤差 |
+|-----------|----------|
+| ≥ 200 筆 | ±2% |
+| 50–199 筆 | ±3% |
+| < 50 筆 | ±5% |
+| ≤ 20 筆（example） | 僅 sanity check，不強制對比 |
+
+超出容差必須查明原因（通常是 preprocessing、prompt 格式、或答案正規化邏輯差異）並在文件說明。
+
+## 第 5 步：速度對比（§6.4）
+
+速度是本專案的核心賣點，必須記錄：本專案總耗時 / 並行 worker 數 / 模型名稱，以及參考框架在
+同等硬體、同等題數下的耗時。無法直接對比就註明原因。
+
+## 第 6 步：文件
+
+```bash
+cp docs/evals/TEMPLATE.md docs/evals/{name}.md
+```
+
+填完所有 `{...}` 欄位，特別是第 6 節（分數對比）與第 7 節（速度對比）——**這兩節空著不得合入**。
+
+### 同時更新 datasets/example/README.md（§6.5.1）
+
+三個地方都要改，漏一個就不符合合入條件：
+
+1. 「資料集清單」表格新增條目（目錄、來源、題數、評測方法、說明）
+2. 「快速開始」新增對應的 config.yaml 範例
+3. 「資料格式」新增該 benchmark 的 JSONL 格式說明
+
+## 第 7 步：測試（§6.6）
+
+`tests/test_{name}.py`，**必須能在不呼叫任何外部 API 的情況下通過**（pure unit test）。
+必備覆蓋：
+
+1. **Extractor** — `get_name()`、`extract()` 行為、flag（`uses_*`）
+2. **Scorer** — `get_name()`、`normalize()`、`score()` 的正確/錯誤/空值/無效 ground truth
+3. **`score_full()`**（若有）— 回傳結構驗證
+4. **Checker / 評分邏輯** — 挑 3–5 種代表性 rule type，各寫一個 pass 與一個 fail
+5. **Checker Registry**（若有）— 所有指令 ID 都已註冊、數量正確、category 齊全
+6. **PRESETS 註冊** — `PRESETS["{name}"]` 存在且對應正確的類別
+7. **Example Dataset** — 檔案存在、必要欄位齊全、筆數符合、涵蓋所有子類別
+8. **Edge cases** — 空回應、None、kwargs 內的 null 過濾
+
+```bash
+python3 -m pytest tests/test_{name}.py -v    # 新增測試全過
+python3 -m pytest tests/ -v                  # 完整套件無新增失敗
+```
+
+既有失敗（版本不一致、缺本機 fixture）要確認在本次變更**之前**就存在，並在 PR 描述說明。
+
+## 第 8 步：合入前檢查
+
+§6.0.1 的合入前提，全部要打勾：
+
+- [ ] 6 個 Issue 都已 close（或在同一 PR 解決）
+- [ ] `docs/evals/{name}.md` 完整，含分數對比與速度對比
+- [ ] 分數誤差符合容差標準
+- [ ] `datasets/example/{name}/` 有 10–20 筆
+- [ ] `datasets/example/README.md` 三處都更新
+- [ ] `tests/test_{name}.py` 全過，完整套件無新增失敗
+- [ ] 移植的程式碼有 attribution 註解與授權記錄
+- [ ] 新依賴都在 `[project.optional-dependencies]`
+
+### push 前：強制 reviewer agent（§13）
+
+**這條沒有例外。** 開 PR 前、以及後續每一次 push 新 commit 前，都必須 spawn 一個獨立的
+reviewer agent 審自己的 diff：
+
+```
+Agent(subagent_type="general-purpose", prompt="""
+審查 {branch} 的變更。先讀 CLAUDE.md，再讀 git diff main...HEAD。
+變更動機：{為什麼這樣改}
+找：bug、違反 CLAUDE.md 原則之處、邊界條件、測試漏洞。
+回報 BLOCKER / SHOULD-FIX / NIT 三層，每項附檔案:行號與具體觸發情境。
+""")
+```
+
+- Reviewer 回報 blocker **必須在 push 前修掉**
+- should-fix / nit 至少要在 PR 描述說明處置方式（修了 / 開 follow-up / 為何不修）
+- 不得自己 review 自己——coding agent 對剛寫的程式碼有確認偏差
+
+### 版號（§11）
+
+Milestone 全部 Issue close → bump **MINOR**（新增 benchmark 屬新功能）。
+同步改 `pyproject.toml` 與 `twinkle_eval/__init__.py`，更新 `CHANGELOG.md`，
+建 tag 並 `gh release create`，然後 close Milestone。

--- a/.claude/skills/run-eval/SKILL.md
+++ b/.claude/skills/run-eval/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: run-eval
+description: 用 Twinkle Eval 跑一次評測——建立 config.yaml、下載或指定資料集、驗證設定、執行並讀結果。當使用者說「跑 benchmark」「跑評測」「建 config」「evaluate 這個模型」「twinkle-eval 怎麼跑」「評測結果怎麼看」「為什麼分數是 0」時使用。涵蓋 15 種 evaluation_method 的 config 差異、27 個內建可下載 benchmark、--validate / --dry-run / --resume，以及用 unparsed_rate 診斷 extractor 失效。
+---
+
+# 跑一次評測
+
+## 前提：本專案不啟動模型服務
+
+Twinkle Eval 只做一件事——**拿題目去呼叫已經在外部運行的 OpenAI 相容端點**。
+模型要自己先起好（vLLM、Ollama、OpenAI、NVIDIA Build 都行），再把 `base_url` 填進 config。
+
+端點沒回應時，本專案的正確行為是依 `max_retries` 重試後報錯退出，**不會**也**不該**嘗試
+重啟服務（CLAUDE.md 原則 G）。
+
+## 1. 產生 config
+
+```bash
+twinkle-eval --init                  # 列出全部 11 個範本
+twinkle-eval --init multiple_choice  # 產生 configs/multiple_choice.yaml
+twinkle-eval --init all              # 全部產生到 configs/
+```
+
+範本存放在 `twinkle_eval/templates/`，`--init` 直接掃該目錄。
+
+### config 骨架
+
+```yaml
+llm_api:
+  base_url: "http://localhost:8000/v1"   # 必填
+  api_key: "EMPTY"                       # 必填（本地 vLLM 隨便填）
+  api_rate_limit: -1                     # QPS，-1 為不限
+  max_retries: 3
+  timeout: 600
+  disable_ssl_verify: false
+
+model:
+  name: "my-model"                       # 必填，會寫進結果路徑與紀錄
+  temperature: 0.0
+  top_p: 0.9
+  max_tokens: 4096
+  extra_body:                            # 傳給 API 的額外參數
+
+evaluation:
+  dataset_paths:                         # 必填，list（即使只有一個）
+    - "datasets/example/tmmluplus/"
+  evaluation_method: "box"               # 必填，見下表
+  repeat_runs: 1                         # >1 時算平均與標準差
+  shuffle_options: false                 # 選項隨機排列
+
+logging:
+  level: "INFO"
+```
+
+**每個 evaluation_method 的必填欄位與 `strategy_config` 參數不同**，
+完整對照見 `references/config-reference.md`。
+
+### 挑 evaluation_method
+
+| 方法 | 用在 | 備註 |
+|------|------|------|
+| `pattern` | 選擇題，通用首選 | 正則比對，含中英文預設模式 |
+| `box` | 選擇題，推理模型 | 提取 `\boxed{}` / `\box{}`；**需要 `system_prompt`** |
+| `logit` | 多選項題 | 比較各選項 log-probability，不依賴輸出格式；選項數不限 |
+| `math` | 數學推理 | `\boxed{}` + MathRuler；需 `[math]` |
+| `regex_match` | BBH 之類自由格式 | ⚠️ `system_prompt` **不生效**，見下方說明 |
+| `custom_regex` | 自訂格式 | 必須設 `strategy_config.patterns` |
+| `ifeval` / `ifbench` | 指令遵循 | 需 `[ifeval]` / `[ifbench]` + nltk 資料 |
+| `bfcl_fc` / `bfcl_prompt` | 函式呼叫 | FC 走 tools API，prompt 走注入 |
+| `niah` | 長文本大海撈針 | |
+| `ragas` | RAG 品質 | |
+| `text2sql` | Text-to-SQL | 需設 `text2sql_db_base_path` |
+| `asr` | 語音辨識 | 需 `[asr]`；`llm_api.type: whisper` 或多模態 |
+| `vision_mcq` | 視覺多選題 | 需 `[vision]`（縮放用） |
+
+> ⚠️ **`evaluation.system_prompt` 只對 `box` 與 `math` 生效。**
+> `models/openai.py` 的 `_build_messages()` 以白名單決定是否送出 system message
+> （`method in {"box", "math"}`），其他方法即使在 config 設了 `system_prompt` 也不會進 request。
+> `regex_match` 這類需要指定輸出格式的方法，格式要求必須寫進資料集的 `question` 欄位裡。
+> （專案的 `templates/regex_match.yaml` 目前有同樣的誤導，見 [#144](https://github.com/ai-twinkle/Eval/issues/144)）
+
+```bash
+twinkle-eval --list-strategies   # 執行期確認可用方法
+```
+
+## 2. 準備資料集
+
+```bash
+twinkle-eval --download-dataset list          # 列出 27 個內建 benchmark
+twinkle-eval --download-dataset mmlu          # 短名稱
+twinkle-eval --download-dataset tmmluplus gsm8k
+twinkle-eval --download-dataset all
+```
+
+內建短名稱：`mmlu` `mmlu_pro` `mmlu_redux` `tmmluplus` `supergpqa` `gpqa` `formosa_bench`
+`gsm8k` `aime2025` `bbh` `ifeval` `ifbench` `bfcl` `needlebench` `longbench` `wikieval`
+`librispeech` `aishell1` `fleurs` `common_voice` `mmbench` `mmstar` `mmmu` `pope`
+`spider` `bird` `spider2_lite`
+
+`gpqa` 是 gated dataset，會互動式要求 HuggingFace token。
+
+**先用 example 資料集驗證流程跑得通**再下載完整 benchmark：
+`datasets/example/` 底下每個 benchmark 都有 10–30 筆的子集，跑一次只要幾秒。
+
+## 3. 本機 config 的命名規則（重要）
+
+含真實 API 金鑰的 config **絕對不得 commit**（CLAUDE.md 原則 E）。這三種前綴/後綴已被
+`.gitignore` 全局排除，本機測試一律用其中之一：
+
+```
+config_local_*.yaml
+config_test_*.yaml
+*.local.yaml
+```
+
+寫入任何含金鑰的 config 前，**先確認該路徑已在 `.gitignore` 中**。不確定就檢查：
+
+```bash
+git check-ignore -v config_local_myrun.yaml   # 有輸出 = 已被忽略
+git diff --staged | grep -i "api_key"         # commit 前確認
+```
+
+## 4. 執行
+
+```bash
+twinkle-eval --validate --config config_local_myrun.yaml   # 只驗設定與資料集，不呼叫 API
+twinkle-eval --dry-run  --config config_local_myrun.yaml   # 顯示評測計畫，不呼叫 API
+twinkle-eval --config config_local_myrun.yaml              # 正式跑
+twinkle-eval --config config_local_myrun.yaml --export json csv html excel
+```
+
+**永遠先跑 `--validate` 再跑正式評測。** 資料集路徑錯、缺必填欄位、格式不符都會在這一步
+抓到，省下一整輪 API 費用與時間。
+
+中斷後續跑（⚠️ 目前失效，見 [#145](https://github.com/ai-twinkle/Eval/issues/145)）：
+
+```bash
+twinkle-eval --resume 20260825_1430 --config config_local_myrun.yaml
+```
+
+## 5. 讀結果
+
+```
+results/
+├── results_{timestamp}.json                 # 整體摘要
+└── eval_results_{timestamp}_run{N}.jsonl    # 各題明細（append 模式）
+```
+
+摘要含 `dataset_results`（各資料集的 `average_accuracy`、`average_std`、
+`average_pass_at_k`、`total_unparsed_count`）與 `duration_seconds`。
+`config` 欄位是**移除 api_key 後**的設定。
+
+明細每行含 `question_id` / `sample_id` / `question` / `correct_answer` /
+`predicted_answer` / `is_correct` / `llm_output` / `llm_reasoning_output` / token 用量。
+各路徑另有增補欄位（`logit` 的 `logprob_scores`、`ifeval` 的四個指標、`vision_mcq` 的
+`image_path`、`asr` 的 `wer` / `cer`）。
+
+> ⚠️ 實際輸出**沒有** `file` 與 `timestamp` 欄位（CLAUDE.md §10 的規範與實作不符）。
+> 這也讓 `--resume` 目前無法運作：它以 `{file}|{question_id}` 作為已完成紀錄的 key，
+> `file` 缺失使得 key 變成 `|{idx}`，與比對端的 `{檔案路徑}|` 永遠不匹配，
+> 結果是一題都不會跳過、整輪重跑並 append 出重複列。見 [#145](https://github.com/ai-twinkle/Eval/issues/145)。
+
+```bash
+# 快速看正確率
+jq -r '.dataset_results | to_entries[] | "\(.key): \(.value.average_accuracy)"' \
+  results/results_*.json
+
+# 撈出所有答錯的題目
+jq -c 'select(.is_correct == false) | {question_id, predicted_answer, correct_answer}' \
+  results/eval_results_*_run0.jsonl | head
+```
+
+## 診斷：分數異常低
+
+先看 **`unparsed_rate`**——這是判斷「模型答錯」還是「extractor 沒抓到」的關鍵。
+
+```bash
+# 資料集層級（摘要 JSON 用 average_unparsed_rate，per-file 才叫 unparsed_rate）
+jq -r '.dataset_results | to_entries[] | "\(.key): \(.value.average_unparsed_rate)"' \
+  results/results_*.json
+```
+
+| 症狀 | 多半是 |
+|------|--------|
+| `unparsed_rate` 高（>10%） | extractor 沒對上輸出格式 |
+| `unparsed_rate` ≈ 0 但分數低 | 模型是真的答錯 |
+| 全部 0 分且無 unparsed | ground truth 欄位或正規化對不上 |
+| 「所有資料集評測均失敗」 | 資料集路徑、格式，或 API 端點問題 |
+
+extractor 沒抓到時，撈幾筆 `llm_output` 出來看實際格式：
+
+```bash
+jq -r 'select(.predicted_answer == null) | .llm_output' \
+  results/eval_results_*_run0.jsonl | head -3
+```
+
+常見成因：
+
+- **`box` 方法但沒設 `system_prompt`** → 模型不知道要用 `\boxed{}`，自然抓不到
+- **推理模型的 think tag** → evaluator 會剝離完整的 `<think>...</think>` / `<reason>` /
+  `<reasoning>` 標籤對；只有結尾 tag 而無開頭 tag 會被視為格式不合格而原樣保留
+- **`content` 為 null**（vLLM `skip_special_tokens=true`）→ 會回退讀 `reasoning`，
+  再回退 `reasoning_content`（vLLM 0.18+ 改名，兩者都支援）
+- **選項超過 4 個**（MMLU-Pro A–J、SuperGPQA）→ 確認 extractor 支援多字母選項
+
+## 效能
+
+並行度由 `ThreadPoolExecutor` 預設值決定，用 `llm_api.api_rate_limit` 節流：
+
+- 本地 vLLM：`-1`（不限）
+- 有 QPS 限制的商用 API：設成實際上限，否則會大量 429
+
+`repeat_runs > 1` 會線性放大時間，但能得到標準差——量化模型穩定性時才開。

--- a/.claude/skills/run-eval/references/config-reference.md
+++ b/.claude/skills/run-eval/references/config-reference.md
@@ -1,0 +1,281 @@
+# config.yaml 完整參照
+
+各 `evaluation_method` 的必填欄位與 `strategy_config` 參數對照。
+欄位名稱一律 snake_case；新欄位都有預設值，舊 config 不會因新版本報錯。
+
+## 通用區塊
+
+### `llm_api`
+
+| 欄位 | 預設 | 說明 |
+|------|------|------|
+| `base_url` | —（必填） | OpenAI 相容端點，含 `/v1` |
+| `api_key` | —（必填） | 本地服務隨便填；**儲存結果時會自動移除** |
+| `type` | `openai` | `openai` / `whisper`（ASR 專用） |
+| `api_rate_limit` | `-1` | 每秒請求數，`-1` 為不限 |
+| `max_retries` | `3` | 失敗重試次數 |
+| `timeout` | `600` | 單次請求逾時（秒） |
+| `disable_ssl_verify` | `false` | 自簽憑證環境設 `true` |
+
+### `model`
+
+| 欄位 | 預設 |
+|------|------|
+| `name` | —（必填），會寫進結果路徑 |
+| `temperature` | `0.0` |
+| `top_p` | `0.9` |
+| `max_tokens` | `4096` |
+| `frequency_penalty` | `0.0` |
+| `presence_penalty` | `0.0` |
+| `extra_body` | `{}` — 傳給 API 的額外參數，如 `{"chat_template_kwargs": {...}}` |
+
+### `evaluation`
+
+| 欄位 | 預設 | 說明 |
+|------|------|------|
+| `dataset_paths` | —（必填） | list，即使只有一個路徑 |
+| `evaluation_method` | —（必填） | 見下方各方法 |
+| `system_prompt` | — | `{zh: ..., en: ...}`；`box` / `math` 會用 |
+| `system_prompt_enabled` | `true` | |
+| `datasets_prompt_map` | `{}` | `{"datasets/mmlu/": "en"}` 指定資料集用哪種語言 |
+| `repeat_runs` | `1` | >1 時計算平均與標準差 |
+| `shuffle_options` | `false` | 選項隨機排列，消除位置偏好 |
+| `samples_per_question` | `1` | 每題採樣數（pass@k 用） |
+| `pass_k` | `1` | |
+| `strategy_config` | `{}` | 傳給 Extractor / Scorer 的參數 |
+| `dataset_overrides` | `{}` | 依資料集路徑前綴覆寫設定，見下 |
+
+### `dataset_overrides`
+
+同一次 run 內對不同資料集套不同設定，key 是路徑前綴：
+
+```yaml
+evaluation:
+  dataset_overrides:
+    "datasets/gsm8k/":
+      system_prompt_enabled: false
+      temperature: 0.6
+    "datasets/aime2025/":
+      samples_per_question: 8
+      pass_k: 4
+```
+
+可覆寫：`evaluation_method`、`system_prompt_enabled`、`samples_per_question`、
+`pass_k`、`repeat_runs`、`shuffle_options`，以及 model 參數
+`temperature` / `top_p` / `max_tokens` / `frequency_penalty` / `presence_penalty`。
+
+### `logging`
+
+`level`: `DEBUG` / `INFO` / `WARNING` / `ERROR`
+
+---
+
+## 各方法專屬設定
+
+### `pattern` — 正則比對（選擇題通用）
+
+```yaml
+evaluation:
+  evaluation_method: "pattern"
+  strategy_config:
+    patterns:            # 可選，覆寫預設的中英文模式
+      - "答案[是為：:]\\s*([A-Z])"
+```
+
+### `box` — 提取 `\boxed{}`
+
+**必須設 `system_prompt`**，否則模型不會用 `\boxed{}` 格式，全部抓不到。
+
+```yaml
+evaluation:
+  evaluation_method: "box"
+  system_prompt:
+    zh: "請將最終答案放在 \\boxed{} 中。"
+    en: "Put your final answer in \\boxed{}."
+  strategy_config:
+    patterns: [...]      # 可選
+```
+
+### `logit` — 比較選項 log-probability
+
+不生成文字，改用 `/v1/completions` 的 echo 模式逐選項算 log-likelihood。
+端點必須支援 completions API 與 `logprobs`。適合多選項題，完全不依賴輸出格式。
+
+```yaml
+evaluation:
+  evaluation_method: "logit"
+```
+
+### `math` — 數學推理
+
+```yaml
+evaluation:
+  evaluation_method: "math"
+  system_prompt:
+    zh: "請逐步推理，並將最終答案放在 \\boxed{} 中。"
+```
+
+需 `pip install twinkle-eval[math]`（mathruler、sympy、pylatexenc）。
+
+### `custom_regex` — 自訂正則
+
+**必須**設 `strategy_config.patterns`，否則初始化就會失敗。
+
+```yaml
+evaluation:
+  evaluation_method: "custom_regex"
+  strategy_config:
+    patterns:
+      - "final answer:\\s*([A-Z])"
+```
+
+### `regex_match` — 自由格式字串比對（BBH）
+
+> ⚠️ **`system_prompt` 對這個方法不生效**（見本檔開頭「`evaluation`」一節與
+> [#144](https://github.com/ai-twinkle/Eval/issues/144)）。`models/openai.py` 的白名單只認
+> `box` / `math`。輸出格式要求必須寫進資料集的 `question` 欄位，寫在 config 裡不會送出。
+> 專案的 `templates/regex_match.yaml` 目前仍有這個誤導。
+
+```yaml
+evaluation:
+  evaluation_method: "regex_match"
+  # 注意：這裡不放 system_prompt——設了也不會送出
+  strategy_config:
+    answer_pattern: [...]        # 可選，覆寫預設
+    normalize_mode: "strip"      # strip / upper / lower / none（非法值會 raise ValueError）
+```
+
+### `ifeval` / `ifbench` — 指令遵循
+
+```yaml
+evaluation:
+  evaluation_method: "ifeval"
+  dataset_paths: ["datasets/ifeval/"]
+```
+
+資料集欄位：`id`、`question`（IFBench 用 `prompt`）、`instruction_id_list`、`kwargs`。
+兩者都吃 JSON string 與原生 list/dict。
+
+```bash
+pip install twinkle-eval[ifeval]     # langdetect, nltk
+pip install twinkle-eval[ifbench]    # emoji, syllapy, nltk
+python -c "import nltk; nltk.download('punkt_tab')"
+```
+
+輸出四個指標：`prompt_strict` / `prompt_loose` / `instruction_strict` / `instruction_loose`。
+`accuracy` 等同 `prompt_strict`。
+
+### `bfcl_fc` / `bfcl_prompt` — 函式呼叫
+
+- `bfcl_fc`：把 function 定義轉成 OpenAI `tools` 送出，讀 `message.tool_calls`。端點必須支援 tool calling。
+- `bfcl_prompt`：把 function 定義注入 system prompt，從文字回應解析。
+
+```yaml
+evaluation:
+  evaluation_method: "bfcl_fc"
+  dataset_paths:
+    - "datasets/bfcl/simple/"
+    - "datasets/bfcl/multiple/"
+    - "datasets/bfcl/parallel/"
+  repeat_runs: 1          # ground truth 固定，跑 1 次即可
+```
+
+資料集欄位：`question`（JSON messages）、`functions`（JSON）、`answer`。
+需 `pip install twinkle-eval[tool]`。
+
+### `niah` — 長文本大海撈針
+
+```yaml
+evaluation:
+  evaluation_method: "niah"
+  strategy_config:
+    niah_scoring_mode: "substring"   # substring / exact / f1（LongBench passage_retrieval_zh 用 exact）
+    niah_f1_threshold: 0.5
+```
+
+### `ragas` — RAG 品質
+
+```yaml
+evaluation:
+  evaluation_method: "ragas"
+  strategy_config:
+    ragas_threshold: 0.5
+```
+
+### `text2sql` — Text-to-SQL
+
+```yaml
+evaluation:
+  evaluation_method: "text2sql"
+  strategy_config:
+    text2sql_scoring_mode: "exec"                        # exec / em（只有 "em" 走 Exact Match，
+                                                         # 其他任何值都落進 exec 分支，無驗證）
+    text2sql_db_base_path: "datasets/spider/databases"   # exec 模式必填
+    text2sql_timeout: 30
+```
+
+`exec` 模式會實際執行 SQL 比對結果集，需要資料庫檔案在 `text2sql_db_base_path` 底下。
+
+> ⚠️ 下列任一情況會**靜默回退成 Exact Match**且不留 log：`db_base_path` 為空、
+> 題目缺 `db_id`、對應的 `.sqlite` 不存在、或 gold SQL 執行失敗。
+> 分數看起來偏低時，先確認資料庫檔案路徑正確。
+
+### `asr` — 語音辨識
+
+兩條路徑：Whisper API（`llm_api.type: whisper`）或 Chat Completions 多模態。
+
+```yaml
+llm_api:
+  type: "whisper"
+evaluation:
+  evaluation_method: "asr"
+  strategy_config:
+    asr_language: "zh"           # 語言代碼
+    asr_metric: "auto"           # auto（依語言選）/ wer / cer
+    remove_punctuation: true
+    to_lower: true
+    normalize_unicode: true      # NFKC
+```
+
+資料集欄位：`audio_path`（或 `question`）、`answer`。
+需 `pip install twinkle-eval[asr]`（jiwer）。額外輸出 `avg_wer` / `avg_cer`。
+
+### `vision_mcq` — 視覺多選題
+
+```yaml
+evaluation:
+  evaluation_method: "vision_mcq"
+  strategy_config:
+    image_field: "image_path"    # 圖片路徑/URL 的欄位名
+    max_image_size: null         # 最長邊像素；null 不縮放（縮放需 Pillow）
+    image_detail: "auto"         # auto / low / high
+```
+
+支援本地檔案（自動 base64 data URI，magic bytes 偵測 MIME）與 http(s) URL（直接傳遞）。
+單張圖片上限 50 MB。需 `pip install twinkle-eval[vision]`（僅縮放需要）。
+
+支援字母答案（A–Z）與 Yes/No 二元答案（POPE 等幻覺偵測），優先解析 `\boxed{}`。
+
+---
+
+## 輸出格式
+
+```yaml
+# CLI: --export json csv html excel google_sheets
+# 注意：excel 需要 openpyxl，但它目前未被宣告為依賴，乾淨環境會在評測跑完後才失敗
+#       見 https://github.com/ai-twinkle/Eval/issues/147
+```
+
+`results_{timestamp}.json` 必要欄位：`timestamp`、`config`（已移除 api_key）、
+`dataset_results`、`duration_seconds`。
+
+`eval_results_{timestamp}_run{N}.jsonl` 每行實際欄位：`question_id`、`sample_id`、
+`question`、`correct_answer`、`predicted_answer`、`is_correct`、`llm_output`、
+`llm_reasoning_output`、`usage_*`。各路徑另有增補欄位：`logit` 有 `logprob_scores`、
+`ifeval` / `ifbench` 有 `prompt_strict` / `prompt_loose` / `instruction_strict` /
+`instruction_loose`、`vision_mcq` 有 `image_path`、`asr` 有 `wer` / `cer`。
+寫入一律 append 模式，確保多檔多 run 累積不遺失。
+
+> ⚠️ CLAUDE.md §10 規定每行要有 `timestamp` 與 `file`，但實作並未寫出這兩個欄位。
+> `file` 缺失導致 `--resume` 無法運作（它以 `{file}|{question_id}` 為 key），見 [#145](https://github.com/ai-twinkle/Eval/issues/145)。
+> 既有欄位名稱不得修改（向下相容）。

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ configs/*.yaml
 # personal analysis notes (not for commit)
 issues_analysis.md
 .gstack/
+
+# Claude Code 本機設定（含 permission 規則，可能夾帶 API 金鑰，不得進版控）
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Twinkle Eval 是一個以**並行 API 請求**為核心的 LLM 評測框架，�
 
 ## 目錄
 
+- [Claude Code Skills](#claude-code-skills)
 - [為什麼選擇 Twinkle Eval](#為什麼選擇-twinkle-eval)
 - [支援的評測資料集](#支援的評測資料集)
 - [評測方法一覽](#評測方法一覽)
@@ -33,6 +34,42 @@ Twinkle Eval 是一個以**並行 API 請求**為核心的 LLM 評測框架，�
 - [授權條款](#授權條款)
 - [引用](#引用)
 - [致謝](#致謝)
+
+---
+
+## Claude Code Skills
+
+本專案內建兩個 [Claude Code](https://claude.com/claude-code) skill，隨 repo 進版控，**clone 下來就能用**，不需要額外安裝。它們把 `CLAUDE.md` 裡最冗長、最容易漏步驟的流程變成可執行的指引。
+
+| Skill | 用途 |
+|-------|------|
+| `/run-eval` | 建立 config.yaml、下載資料集、跑評測、讀結果、診斷分數異常 |
+| `/add-benchmark` | 新增一個評測 benchmark 的完整流程（貢獻者用） |
+
+Skill 會在對話內容相關時**自動生效**，也可以直接輸入斜線指令叫用：
+
+```
+/run-eval          我要用 TMMLU+ 評測 localhost:8000 上的模型
+/add-benchmark     幫我加一個 MMLU-CF 評測
+```
+
+### `/run-eval` — 跑評測
+
+涵蓋 15 種 `evaluation_method` 的 config 差異、27 個內建可下載 benchmark 的短名稱、
+`--validate` / `--dry-run` / `--resume` 的用法，以及本機 config 的命名規則（避免 API 金鑰進版控）。
+
+附一份完整的 [config 欄位參照](.claude/skills/run-eval/references/config-reference.md)，
+逐一列出每種評測方法的必填欄位與 `strategy_config` 參數。
+
+最實用的是**診斷章節**：分數異常低時，先看 `unparsed_rate` 區分「模型真的答錯」與
+「extractor 沒抓到輸出格式」，並列出 `box` 未設 system_prompt、推理模型的 think tag、
+`content=null` 等常見成因。
+
+### `/add-benchmark` — 新增評測方法
+
+把 `CLAUDE.md` §6 的強制流程展開成可執行清單：先建 Milestone 與 6 個 Issue（附 `gh` 指令）、
+example dataset 規格、Extractor + Scorer 骨架與 `PRESETS` 註冊、evaluator 七條資料流的分派表、
+分數容差標準、速度對比、文件與測試要求，以及 push 前的強制 reviewer agent 規定。
 
 ---
 
@@ -61,7 +98,7 @@ Twinkle Eval 是一個以**並行 API 請求**為核心的 LLM 評測框架，�
 
 ## 支援的評測資料集
 
-Twinkle Eval 內建 23 個評測資料集的下載支援，涵蓋 9 大評測類型。所有資料集皆可透過 `--download-dataset` 一鍵下載。
+Twinkle Eval 內建 27 個評測資料集的下載支援，涵蓋 9 大評測類型。所有資料集皆可透過 `--download-dataset` 一鍵下載。
 
 ### 選擇題（Multiple Choice）
 
@@ -153,6 +190,7 @@ Twinkle Eval 內建 23 個評測資料集的下載支援，涵蓋 9 大評測類
 | `ragas` | RAG | 以 LLM-as-Judge 評估 RAG 品質 |
 | `asr` | 語音辨識 | WER/CER 計算（支援 Whisper API 與 Chat Completions 多模態） |
 | `text2sql` | Text-to-SQL | SQL 執行結果比對 |
+| `vision_mcq` | 視覺多選題 | VLM 圖片理解選擇題（支援字母答案與 Yes/No 二元判斷） |
 
 ---
 
@@ -271,7 +309,7 @@ results = runner.run_evaluation(export_formats=["json", "csv"])
 | `--validate` | 驗證設定檔格式與資料集路徑 |
 | `--dry-run` | 載入設定與資料集，顯示評測計畫但不呼叫 API |
 | `--resume TIMESTAMP` | 從指定時間戳的中斷點繼續評測 |
-| `--export FORMAT [FORMAT ...]` | 輸出格式（json, csv, html） |
+| `--export FORMAT [FORMAT ...]` | 輸出格式（json, csv, html, excel, google_sheets） |
 | `--finalize-results TIMESTAMP` | 合併分散式評測碎片並重新計算指標 |
 | `--hf-repo-id REPO` | 評測完成後上傳結果至 HuggingFace |
 | `--list-llms` | 列出支援的 LLM 類型 |
@@ -344,6 +382,8 @@ logging:
 本專案歡迎使用 Coding Agent 進行開發。我們提供了完整的 [`CLAUDE.md`](CLAUDE.md) 規範文件，涵蓋專案架構、設計原則、擴充規範、PR checklist 等所有開發所需的上下文。
 
 **建議的工作流程**：讓你的 Coding Agent 在開始任何工作之前，先完整閱讀 `CLAUDE.md`，這能大幅提升產出品質並減少來回修改。
+
+使用 Claude Code 的話，本專案已內建對應的 skill，見 [Claude Code Skills](#claude-code-skills)。
 
 支援的 Coding Agent：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,6 +13,7 @@ This project is a Large Language Model (LLM) evaluation framework that uses conc
 
 ## Table of Contents
 
+- [Claude Code Skills](#claude-code-skills)
 - [Key Features](#key-features)
 - [Performance Metrics](#performance-metrics)
 - [Technical Highlights](#technical-highlights)
@@ -32,6 +33,36 @@ This project is a Large Language Model (LLM) evaluation framework that uses conc
 - [License](#license)
 - [Citation](#citation)
 - [Acknowledgments](#acknowledgments)
+
+## Claude Code Skills
+
+This repository ships two [Claude Code](https://claude.com/claude-code) skills. They are version-controlled with the repo, so they work as soon as you clone it -- no extra installation. They turn the longest, easiest-to-miss procedures in `CLAUDE.md` into executable guidance.
+
+| Skill | Purpose |
+|-------|---------|
+| `/run-eval` | Build a config.yaml, download datasets, run an evaluation, read results, diagnose bad scores |
+| `/add-benchmark` | The full procedure for adding a new evaluation benchmark (for contributors) |
+
+Skills activate automatically when the conversation is relevant, or you can invoke them directly:
+
+```
+/run-eval          evaluate the model on localhost:8000 with TMMLU+
+/add-benchmark     add an MMLU-CF benchmark
+```
+
+**`/run-eval`** covers the config differences across all 15 `evaluation_method` values, the short
+names for the 27 built-in downloadable benchmarks, `--validate` / `--dry-run` / `--resume`, and the
+naming rules that keep local configs (with API keys) out of version control. It ships a full
+[config field reference](.claude/skills/run-eval/references/config-reference.md), plus a diagnostic
+section: when scores look wrong, check `unparsed_rate` first to tell "the model got it wrong" apart
+from "the extractor did not match the output format".
+
+**`/add-benchmark`** expands the mandatory process in `CLAUDE.md` §6 into a checklist: create the
+Milestone and 6 Issues first, example dataset requirements, the Extractor + Scorer skeleton and
+`PRESETS` registration, the evaluator's seven data-flow routes, score tolerance thresholds, speed
+comparison, docs and test requirements, and the mandatory reviewer agent before any push.
+
+---
 
 ## Key Features
 


### PR DESCRIPTION
## 動機

把 `CLAUDE.md` 裡最冗長、最容易漏步驟的兩個流程做成 Claude Code skill，隨 repo 進版控，clone 下來就能用。

| Skill | 對象 | 內容 |
|-------|------|------|
| `/run-eval` | 使用者 | 建 config.yaml、下載資料集、跑評測、讀結果、診斷分數異常 |
| `/add-benchmark` | 貢獻者 | 展開 §6 新增 benchmark 的強制流程 |

Skill 會在對話內容相關時自動生效，也可直接以斜線指令叫用。

## 這個 PR 順帶抓出 4 個既有 bug

寫 skill 時我沒有照抄專案自己的 template 與文件，而是逐條對照程式碼驗證——結果發現**文件與實作在四個地方不符**。Skill 記錄的是程式碼的實際行為，並各開了 issue：

| Issue | 問題 | 嚴重度 |
|-------|------|--------|
| #145 | JSONL 缺 `file` / `timestamp`（違反 §10），導致 **`--resume` 完全失效**——key 變成 `\|{idx}`，與比對端永遠不匹配，一題都不會跳過 | 🔴 功能等同不存在 |
| #144 | `evaluation.system_prompt` 只對 `box` / `math` 生效。`templates/regex_match.yaml` 官方範本設了卻不會送出，使用者會遇到 `unparsed_rate` 飆高而找不到原因 | 🔴 |
| #147 | `--export excel` 是合法選項，但 `openpyxl` 未宣告為依賴，乾淨環境會在**評測跑完之後**才失敗 | 🟡 |
| — | `text2sql_scoring_mode` 只認 `"em"`，包含 template 寫的 `"match"` 在內的任何值都靜默落入 exec 分支且無驗證 | 🟡 已在文件註明 |

## ⚠️ 順帶擋下一次金鑰外洩

`.claude/settings.local.json` 會把 Bash permission 規則原樣存下來，其中captured 了兩把明文 API 金鑰（來自過去的 curl 指令）。把 skills 放進 `.claude/` 會讓 `git add .claude/` 成為自然的下一步，那就會把金鑰寫進歷史，違反原則 E。

已確認**這些金鑰出現在 0 個 commit**，歷史乾淨、不需要重寫，並已加入 `.gitignore`。實測該規則能擋 `settings.local.json` 且不誤擋 `.claude/skills/`。

> 金鑰仍以明文存在該本機檔案中。若那台機器有備份或同步機制，建議輪換。

## README

新章節放在目錄第一條、中英文皆有。順帶修正兩處過期數字：benchmark 數 23 → 27（`BENCHMARK_REGISTRY` 實際為 27）、`--export` 格式列表補上 `excel` / `google_sheets`，並為「評測方法一覽」表格補上遺漏的 `vision_mcq`，使其 15 列與 `PRESETS` 一致。

## 查核方式

Skill 的每一項宣稱都對照程式碼驗證，不是照抄文件：

- 15 種 `evaluation_method` ↔ `PRESETS`
- 27 個 benchmark 短名稱 ↔ `BENCHMARK_REGISTRY`
- 6 個 extractor flag ↔ 各 class attribute 與 `evaluate_file()` 的 if/elif 順序
- CLI 旗標 ↔ `create_cli_parser()`
- 所有 config 預設值 ↔ `core/config.py`
- `strategy_config` 參數名 ↔ 各 Extractor / Scorer 的 `_config.get()`
- 輸出格式 ↔ 實際產生的 `results/` 檔案
- 實跑 `--validate` / `--dry-run` / `--download-dataset list` 確認輸出與文件相符

依 §13 經過三輪獨立 reviewer agent 審查。第一輪找出 3 個 BLOCKER（全是我照抄專案自身文件而未驗證程式碼所致），第三輪找出 B1 的修正只落在 `SKILL.md` 而漏了它指向的參照檔。全部已修。

本 PR 不 close 任何 issue——它開了四個（#144、#145、#147 與文件中註明的 text2sql 行為），留給 maintainer 決定處理順序。
