### PR TITLE
fix: 從 #136 拆出的獨立 bug fix 批次（API 金鑰外洩、結果檔遺失、HTML 崩潰）— 2.8.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.apmic.ai/library/python311
+FROM harbor.apmic.ai/proxy/py311node22:latest
 
 # install uv, but not use by default
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2026-09-11
+
+本版為 PR #136（`Fix/audit bugfix batch`，作者 @dave-apmic）前半段的獨立修復批次，
+內容為不改變評測分數的 bug fix。原 PR 的其餘部分（evaluator 重構、question-level
+resume、新 feature）另行審查。
+
+### Fixed
+- **API 金鑰寫入 benchmark 結果檔**（原則 E 破口）：`--benchmark` 的輸出路徑未經
+  `_prepare_config_for_saving()` 清理，完整的 `llm_api.api_key` 會被寫進
+  `benchmark_results_*.json`。同時修正 `_prepare_config_for_saving()` 會就地刪除
+  `self.config["llm_instance"]` 的問題——那讓同一個 runner 無法重複執行
+  （第二次 `run_evaluation()` 會 `KeyError`）。
+- **`finalize` 刪除合併後的 JSONL**（原則 D 資料遺失）：rank0 的 shard 路徑與合併輸出
+  路徑相同，shard 清理會把剛合併好的結果檔一併刪掉。
+- **HTML exporter 在 `usage_total_tokens` 為 `None` 時崩潰**（`TypeError: int + NoneType`）。
+  同時修正 `llm_resoning_output` 的拼字，使推理輸出能正確顯示——writer 寫出的一直是
+  正確拼字的鍵，exporter 讀的是一個從不存在的鍵。
+- **HTML 報告未轉義模型輸出**：`question`、`correct_answer`、`predicted_answer`、
+  `llm_output`、`reasoning` 現在都經過 `html.escape()`。先前模型回應中若含 `<script>`
+  或任何標籤，會破壞報告版面或直接注入頁面。
+- **`cli.py` 的 `sys.path` hack 遮蔽 HuggingFace `datasets` 套件**：`import datasets` 會
+  解析到專案內的 `twinkle_eval/datasets/`，造成循環 import 錯誤。
+- **text2sql 的 SQL 執行逾時從未生效**：`execute_sql()` 收到 `text2sql_timeout` 後並未實際套用到 sqlite。
+- **gated dataset 檢查的運算子優先序錯誤**：`A and B or C` 導致任何含 `403` 的錯誤都被
+  當成 gated dataset 而靜默略過。
+- **`logs/` 目錄在每次 CLI 呼叫時都被建立**（改為延遲初始化），以及 log 檔名的同分鐘碰撞
+  （時間戳加到秒）。
+
+### Changed
+- **`--dry-run` 與評測啟動不再進行 Google 服務的連線檢查**。原本這些網路呼叫發生在
+  `ConfigurationManager.load_config()`，違反 §4「config.py 不做 API 呼叫」與 §12
+  「`--dry-run` 不呼叫 API」。憑證檔案的格式驗證（存在、JSON 合法、必要欄位、
+  `type == "service_account"`）全部保留。
+  ⚠️ 代價：原本在評測開始前就會擋下的「資料夾不存在或未共享」診斷（含 Service Account
+  email 與三步解法）不再出現，該失敗改為在評測結束的上傳階段才以 log 呈現。
+- **Google Sheets 匯出移除 `API_金鑰` 欄位**（30 → 29 欄）。
+  ⚠️ 既有試算表的歷史列仍保有截斷的金鑰，且在新表頭下會位移一欄，建議封存或清空舊表。
+- **`--download-dataset` 對非 gated 的 403 錯誤現在會以 exit 1 結束**，先前會靜默略過。
+- **text2sql 的 EX 評分現在真的會在 `text2sql_timeout`（預設 30 秒）中止**。
+  ⚠️ 若 gold SQL 本身逾時，該題會退回 Exact Match 評分，可能使 text2sql 分數有小幅變動。
+
+### 注意
+- 秒級時間戳**只套用到 log 檔名**。`results_{timestamp}.json` 與
+  `eval_results_{timestamp}_run{N}.jsonl` 仍為分鐘精度，同分鐘啟動兩次評測會出問題，
+  而且兩個檔案的失效方式不同：
+
+  | 檔案 | 同分鐘第二次執行 |
+  |------|----------------|
+  | `results_{timestamp}.json` | **被覆蓋**，第一次的結果消失 |
+  | `eval_results_{timestamp}_run{N}.jsonl` | **累加**（append 模式），兩次的紀錄混在同一檔 |
+
+  JSONL 的情況更麻煩：資料沒有遺失，但 `results_*.json` 的 `individual_runs.results`
+  仍指向那個檔案，任何從 JSONL 重算正確率的下游工具都會**重複計數**。
+  runner 端的時間戳變更屬於 PR #136 後半段（輸出檔名變更需依 §7 先行討論）。
+
 ## [2.8.0] - 2026-04-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "twinkle-eval"
-version = "2.8.0"
+version = "2.8.1"
 description = "🌟 高效且準確的 AI 模型評測工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_config_sanitization.py
+++ b/tests/test_config_sanitization.py
@@ -1,0 +1,158 @@
+"""config 清理的測試（CLAUDE.md §2 原則 E）。
+
+原則 E 規定 API 金鑰絕對不得出現在輸出、日誌或 Git 歷史中，但在本檔案之前
+`_prepare_config_for_saving()` 完全沒有測試覆蓋——而 `--benchmark` 的輸出路徑
+曾經繞過它，把完整金鑰寫進 `benchmark_results_*.json`。
+"""
+
+import pytest
+
+from twinkle_eval.main import TwinkleEvalRunner
+
+SECRET = "DUMMY-KEY-FOR-TESTS-DO-NOT-LEAK"
+
+
+def make_runner():
+    runner = TwinkleEvalRunner.__new__(TwinkleEvalRunner)
+    runner.config = {
+        "llm_api": {"api_key": SECRET, "base_url": "http://localhost:8000/v1"},
+        "model": {"name": "m"},
+        "evaluation": {"evaluation_method": "box"},
+        "llm_instance": object(),
+        "extractor_instance": object(),
+        "scorer_instance": object(),
+    }
+    return runner
+
+
+class TestPrepareConfigForSaving:
+    def test_api_key_removed(self):
+        saved = make_runner()._prepare_config_for_saving()
+        assert "api_key" not in saved["llm_api"]
+
+    def test_secret_absent_from_serialized_output(self):
+        """不只檢查欄位名——序列化後整份內容都不得含有金鑰字串。
+
+        刻意不加 ``default=str``：production 的 JSONExporter 也沒有，
+        若有殘留的不可序列化物件應該大聲失敗，而非被轉成 repr 掩蓋過去。
+        """
+        import json
+
+        saved = make_runner()._prepare_config_for_saving()
+        assert SECRET not in json.dumps(saved, ensure_ascii=False)
+
+    def test_non_serializable_instances_removed(self):
+        saved = make_runner()._prepare_config_for_saving()
+        for key in ("llm_instance", "extractor_instance", "scorer_instance"):
+            assert key not in saved
+
+    def test_does_not_mutate_live_config(self):
+        """就地修改會讓同一個 runner 無法重複執行（第二次會 KeyError）。"""
+        runner = make_runner()
+        before = set(runner.config)
+        runner._prepare_config_for_saving()
+        assert set(runner.config) == before
+        assert runner.config["llm_api"]["api_key"] == SECRET
+
+    def test_repeatable(self):
+        """連續呼叫兩次都要成功且結果一致。"""
+        runner = make_runner()
+        first = runner._prepare_config_for_saving()
+        second = runner._prepare_config_for_saving()
+        assert first == second
+
+    def test_other_config_preserved(self):
+        saved = make_runner()._prepare_config_for_saving()
+        assert saved["llm_api"]["base_url"] == "http://localhost:8000/v1"
+        assert saved["model"]["name"] == "m"
+        assert saved["evaluation"]["evaluation_method"] == "box"
+
+
+class TestGoogleSheetsHeader:
+    """Sheets 匯出的表頭不得含有金鑰欄位。
+
+    不設 skip 逃生門——若類別或方法被改名，這個測試應該**失敗**而非靜默跳過。
+    """
+
+    def test_header_has_no_api_key_column(self):
+        from unittest.mock import MagicMock
+
+        from twinkle_eval.integrations.google import GoogleSheetsService
+
+        svc = GoogleSheetsService.__new__(GoogleSheetsService)
+        svc.service = MagicMock()
+        svc._create_header("sid", "Sheet1")
+
+        body = svc.service.spreadsheets.return_value.values.return_value.update.call_args.kwargs[
+            "body"
+        ]
+        header = body["values"][0]
+        assert header, "表頭是空的"
+        assert not any(
+            "金鑰" in str(c) or "api_key" in str(c).lower() for c in header
+        ), f"表頭仍含金鑰欄位: {header}"
+
+
+class TestBenchmarkSavePath:
+    """回歸：--benchmark 的輸出路徑曾經把完整金鑰寫進 benchmark_results_*.json。
+
+    這是本批次的頭號修復，而它不在 _prepare_config_for_saving() 裡——它在
+    main() 的 --benchmark 分支內（main.py 的 safe_config）。上面那組測試守不到它。
+    """
+
+    def test_benchmark_output_has_no_api_key(self, tmp_path, monkeypatch):
+        import json
+
+        from twinkle_eval.runners.benchmark import save_benchmark_results
+
+        captured = {}
+
+        def fake_save(metrics, output_path, config):
+            captured["config"] = config
+
+        monkeypatch.setattr("twinkle_eval.main.save_benchmark_results", fake_save, raising=False)
+
+        # 直接驗證 main.py 內的清理邏輯：重現它的結構
+        config = {
+            "llm_api": {"api_key": SECRET, "base_url": "u"},
+            "llm_instance": object(),
+            "extractor_instance": object(),
+            "scorer_instance": object(),
+            "evaluation": {},
+        }
+        import copy as _copy
+
+        safe_config = _copy.deepcopy(
+            {
+                k: v
+                for k, v in config.items()
+                if k
+                not in (
+                    "llm_instance",
+                    "evaluation_strategy_instance",
+                    "extractor_instance",
+                    "scorer_instance",
+                )
+            }
+        )
+        if "llm_api" in safe_config and "api_key" in safe_config["llm_api"]:
+            del safe_config["llm_api"]["api_key"]
+
+        assert SECRET not in json.dumps(safe_config, ensure_ascii=False)
+        assert config["llm_api"]["api_key"] == SECRET, "不得就地破壞原 config"
+
+    def test_main_benchmark_branch_sanitizes(self):
+        """靜態確認 main.py 的 --benchmark 分支確實有清理步驟。
+
+        這條守的是「有人把清理拿掉」——原始的 bug 就是這段根本不存在。
+        """
+        import inspect
+
+        import twinkle_eval.main as m
+
+        src = inspect.getsource(m.main)
+        i = src.find("save_benchmark_results(")
+        assert i != -1, "找不到 save_benchmark_results 呼叫"
+        before = src[:i]
+        assert "safe_config" in before, "--benchmark 在存檔前沒有清理 config"
+        assert 'del safe_config["llm_api"]["api_key"]' in before

--- a/twinkle_eval/__init__.py
+++ b/twinkle_eval/__init__.py
@@ -23,7 +23,7 @@
 授權：MIT License
 """
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 __author__ = "Twinkle AI Team"
 __license__ = "MIT"
 

--- a/twinkle_eval/benchmarks.py
+++ b/twinkle_eval/benchmarks.py
@@ -399,7 +399,7 @@ def _download_hf_benchmark(
                         log_warning(f"  跳過子集 {config}: {e}")
 
     except Exception as e:
-        if info.get("gated") and "401" in str(e) or "403" in str(e):
+        if info.get("gated") and ("401" in str(e) or "403" in str(e)):
             raise _SkipGatedError()
         raise
 
@@ -585,8 +585,10 @@ def _spider2_json_to_jsonl(json_path: str, jsonl_path: str) -> None:
                 "id": item.get("instance_id", item.get("id", "")),
                 "question": item.get("instruction", item.get("question", "")),
                 "answer": json.dumps(
-                    {"sql": item.get("gold", item.get("sql", "")),
-                     "db_id": item.get("db", item.get("db_id", ""))},
+                    {
+                        "sql": item.get("gold", item.get("sql", "")),
+                        "db_id": item.get("db", item.get("db_id", "")),
+                    },
                     ensure_ascii=False,
                 ),
                 "db_id": item.get("db", item.get("db_id", "")),
@@ -656,9 +658,7 @@ def _report_download(dest: str) -> None:
     """報告下載結果的檔案統計。"""
     total_files = sum(len(files) for _, _, files in os.walk(dest))
     total_size = sum(
-        os.path.getsize(os.path.join(dp, f))
-        for dp, _, fns in os.walk(dest)
-        for f in fns
+        os.path.getsize(os.path.join(dp, f)) for dp, _, fns in os.walk(dest) for f in fns
     )
     size_mb = total_size / (1024 * 1024)
     log_info(f"  下載完成：{total_files} 個檔案，共 {size_mb:.1f} MB → {dest}")

--- a/twinkle_eval/cli.py
+++ b/twinkle_eval/cli.py
@@ -5,12 +5,8 @@ Twinkle Eval 命令列介面
 提供 twinkle-eval 命令列工具的入口點，支援各種評測功能和配置選項。
 """
 
-import os
 import sys
 from typing import List, Optional
-
-# 確保能夠正確匯入模組
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from .metrics import get_available_methods
 from .core.logger import log_error

--- a/twinkle_eval/core/config.py
+++ b/twinkle_eval/core/config.py
@@ -180,99 +180,22 @@ class ConfigurationManager:
 
         google_drive_config = google_services_config.get("google_drive", {})
         if google_drive_config.get("enabled", False):
-            try:
-                self._validate_google_drive_config(google_drive_config)
-                log_info("Google Drive 配置驗證完成")
-            except ConfigurationError as e:
-                if "不存在或 Service Account 無權限存取" in str(e):
-                    auth_method = google_drive_config.get("auth_method", "service_account")
-                    if auth_method == "service_account":
-                        log_error(f"Service Account 驗證失敗: {e}")
-                        log_info("建議解決方案:")
-                        log_info("1. 將 Service Account Email 加入 Google Drive 資料夾共享")
-                        log_info("2. 或改用 OAuth 驗證方式：設定 auth_method: 'oauth'")
-                    else:
-                        raise
-                else:
-                    raise
+            self._validate_google_drive_config(google_drive_config)
+            log_info("Google Drive 配置驗證完成")
 
     def _validate_google_sheets_config(self, config: Dict[str, Any]) -> None:
         spreadsheet_id = config.get("spreadsheet_id")
         if not spreadsheet_id or not spreadsheet_id.strip():
             raise ConfigurationError("Google Sheets 配置錯誤: spreadsheet_id 為必填項目")
 
+        # 僅做本地結構驗證；連線與權限問題交由實際匯出時回報。
+        # 設定載入階段不進行任何網路呼叫（config 模組不做 API 呼叫，
+        # 也確保 --validate / --dry-run 不產生網路流量）。
         self._validate_google_auth_config(config, "Google Sheets")
 
-        try:
-            from twinkle_eval.integrations.google import GoogleSheetsService
-
-            sheets_service = GoogleSheetsService(config)
-            sheets_service.service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
-            log_info(f"Google Sheets 連接測試成功 - 試算表 ID: {spreadsheet_id}")
-
-        except Exception as e:
-            raise ConfigurationError(f"Google Sheets 配置驗證失敗: {e}") from e
-
     def _validate_google_drive_config(self, config: Dict[str, Any]) -> None:
+        # 僅做本地結構驗證；資料夾存取權限問題交由實際上傳時回報。
         self._validate_google_auth_config(config, "Google Drive")
-
-        try:
-            from twinkle_eval.integrations.google import GoogleDriveUploader
-
-            drive_uploader = GoogleDriveUploader(config)
-
-            log_folder_id = config.get("log_folder_id")
-            if log_folder_id and log_folder_id.strip():
-                try:
-                    folder_info = (
-                        drive_uploader.service.files()
-                        .get(
-                            fileId=log_folder_id,
-                            fields="id,name,mimeType",
-                            supportsAllDrives=True,
-                        )
-                        .execute()
-                    )
-
-                    if folder_info.get("mimeType") != "application/vnd.google-apps.folder":
-                        raise ConfigurationError(
-                            f"Google Drive log_folder_id 指向的不是資料夾: {log_folder_id}"
-                        )
-
-                    log_info(
-                        f"Google Drive 資料夾驗證成功 - {folder_info.get('name')} ({log_folder_id})"
-                    )
-
-                except Exception as folder_error:
-                    if "File not found" in str(folder_error) or "notFound" in str(folder_error):
-                        service_account_email = None
-                        try:
-                            import json
-
-                            credentials_file = config.get("credentials_file")
-                            with open(credentials_file, "r", encoding="utf-8") as f:
-                                cred_data = json.load(f)
-                                service_account_email = cred_data.get("client_email", "未知")
-                        except Exception:
-                            service_account_email = "未知"
-
-                        raise ConfigurationError(
-                            f"Google Drive 資料夾不存在或 Service Account 無權限存取: {log_folder_id}\n"
-                            f"Service Account: {service_account_email}\n"
-                            f"請確認：\n"
-                            f"1. 資料夾 ID 正確: {log_folder_id}\n"
-                            f"2. 資料夾存在且未被刪除\n"
-                            f"3. Service Account ({service_account_email}) 已被加入資料夾的共享權限"
-                        ) from folder_error
-                    else:
-                        raise ConfigurationError(
-                            f"Google Drive 資料夾驗證失敗: {folder_error}"
-                        ) from folder_error
-
-            log_info("Google Drive 配置驗證完成")
-
-        except Exception as e:
-            raise ConfigurationError(f"Google Drive 配置驗證失敗: {e}") from e
 
     def _validate_google_auth_config(self, config: Dict[str, Any], service_name: str) -> None:
         auth_method = config.get("auth_method", "service_account")

--- a/twinkle_eval/core/logger.py
+++ b/twinkle_eval/core/logger.py
@@ -1,35 +1,55 @@
 import logging
 import os
+import threading
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 # 取得啟動時間
 start_time = datetime.now().strftime("%Y%m%d_%H%M")
 
-# 建立 logs 資料夾（如果不存在）
 logs_dir = "logs"
-os.makedirs(logs_dir, exist_ok=True)
 
-# 設定帶有時間戳的 Log 檔名
+# 帶有時間戳的 Log 檔名
 log_filename = os.path.join(logs_dir, f"evaluation_{start_time}.log")
 
-logging.basicConfig(
-    filename=log_filename,
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    encoding="utf-8",
-)
+_configure_lock = threading.Lock()
+_configured = False
 
 
-def log_info(message):
+def _ensure_configured() -> None:
+    """延遲初始化 logging：首次寫入時才建立 logs/ 目錄與檔案 handler。
+
+    避免 import 副作用——否則連 `twinkle-eval --version` 都會在
+    當前工作目錄產生 logs/ 資料夾。
+    """
+    global _configured
+    if _configured:
+        return
+    with _configure_lock:
+        if _configured:
+            return
+        os.makedirs(logs_dir, exist_ok=True)
+        logging.basicConfig(
+            filename=log_filename,
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            encoding="utf-8",
+        )
+        _configured = True
+
+
+def log_info(message: str) -> None:
+    _ensure_configured()
     logging.info(message)
 
 
-def log_error(message):
+def log_error(message: str) -> None:
+    _ensure_configured()
     logging.error(message)
 
 
-def log_warning(message):
+def log_warning(message: str) -> None:
+    _ensure_configured()
     logging.warning(message)
 
 

--- a/twinkle_eval/core/logger.py
+++ b/twinkle_eval/core/logger.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 # 取得啟動時間
-start_time = datetime.now().strftime("%Y%m%d_%H%M")
+start_time = datetime.now().strftime("%Y%m%d_%H%M%S")
 
 logs_dir = "logs"
 

--- a/twinkle_eval/exporters/__init__.py
+++ b/twinkle_eval/exporters/__init__.py
@@ -3,9 +3,8 @@
 import csv
 import json
 import os
+from html import escape as html_escape
 from typing import Any, Dict, List, Optional, Type
-
-import pandas as pd
 
 from twinkle_eval.core.abc import ResultsExporter
 
@@ -125,6 +124,9 @@ class ExcelExporter(ResultsExporter):
         return ".xlsx"
 
     def export(self, results: Dict[str, Any], output_path: str) -> str:
+        # pandas 僅在實際匯出 Excel 時載入，避免拖慢一般評測的啟動時間
+        import pandas as pd
+
         if not output_path.endswith(self.get_file_extension()):
             output_path += self.get_file_extension()
 
@@ -420,7 +422,7 @@ class HTMLExporter(ResultsExporter):
             <div class="stat-label">錯誤題數</div>
         </div>
         <div class="stat-item">
-            <div class="stat-number" style="color: #007bff;">{sum(d.get('usage_total_tokens', 0) for d in details):,}</div>
+            <div class="stat-number" style="color: #007bff;">{sum(d.get('usage_total_tokens') or 0 for d in details):,}</div>
             <div class="stat-label">總 Token 使用量</div>
         </div>
     </div>
@@ -441,14 +443,15 @@ class HTMLExporter(ResultsExporter):
 
             for i, detail in enumerate(correct_details, 1):
                 question_id = detail.get("question_id", i)
-                question = detail.get("question", "")
-                correct_answer = detail.get("correct_answer", "")
-                predicted_answer = detail.get("predicted_answer", "")
-                llm_output = detail.get("llm_output", "")
-                reasoning = detail.get("llm_resoning_output", "")
-                usage_completion = detail.get("usage_completion_tokens", 0)
-                usage_prompt = detail.get("usage_prompt_tokens", 0)
-                usage_total = detail.get("usage_total_tokens", 0)
+                # 內容一律經過 HTML escape，避免模型輸出中的標籤破壞或注入報表
+                question = html_escape(str(detail.get("question") or ""))
+                correct_answer = html_escape(str(detail.get("correct_answer") or ""))
+                predicted_answer = html_escape(str(detail.get("predicted_answer") or ""))
+                llm_output = html_escape(str(detail.get("llm_output") or ""))
+                reasoning = html_escape(str(detail.get("llm_reasoning_output") or ""))
+                usage_completion = detail.get("usage_completion_tokens") or 0
+                usage_prompt = detail.get("usage_prompt_tokens") or 0
+                usage_total = detail.get("usage_total_tokens") or 0
 
                 html += f"""
             <div class="question-item correct">
@@ -486,14 +489,15 @@ class HTMLExporter(ResultsExporter):
 
             for i, detail in enumerate(incorrect_details, 1):
                 question_id = detail.get("question_id", i)
-                question = detail.get("question", "")
-                correct_answer = detail.get("correct_answer", "")
-                predicted_answer = detail.get("predicted_answer", "")
-                llm_output = detail.get("llm_output", "")
-                reasoning = detail.get("llm_resoning_output", "")
-                usage_completion = detail.get("usage_completion_tokens", 0)
-                usage_prompt = detail.get("usage_prompt_tokens", 0)
-                usage_total = detail.get("usage_total_tokens", 0)
+                # 內容一律經過 HTML escape，避免模型輸出中的標籤破壞或注入報表
+                question = html_escape(str(detail.get("question") or ""))
+                correct_answer = html_escape(str(detail.get("correct_answer") or ""))
+                predicted_answer = html_escape(str(detail.get("predicted_answer") or ""))
+                llm_output = html_escape(str(detail.get("llm_output") or ""))
+                reasoning = html_escape(str(detail.get("llm_reasoning_output") or ""))
+                usage_completion = detail.get("usage_completion_tokens") or 0
+                usage_prompt = detail.get("usage_prompt_tokens") or 0
+                usage_total = detail.get("usage_total_tokens") or 0
 
                 html += f"""
             <div class="question-item incorrect">
@@ -661,9 +665,7 @@ class ResultsExporterFactory:
         """依類型名稱建立輸出器實例。"""
         if exporter_type not in cls._registry:
             available_types = ", ".join(cls._registry.keys())
-            raise ValueError(
-                f"不支援的輸出格式: {exporter_type}. 可用格式: {available_types}"
-            )
+            raise ValueError(f"不支援的輸出格式: {exporter_type}. 可用格式: {available_types}")
 
         # 延遲載入 Google Sheets exporter 以避免循環匯入
         if exporter_type == "google_sheets" and cls._registry[exporter_type] is None:

--- a/twinkle_eval/integrations/google.py
+++ b/twinkle_eval/integrations/google.py
@@ -381,6 +381,10 @@ class GoogleSheetsService:
             if not values or len(values[0]) < 10:
                 log_info("建立 Google Sheets Header...")
                 self._create_header(spreadsheet_id, sheet_name)
+            elif "API_金鑰" in values[0]:
+                # 舊版 Header 含 API 金鑰欄位（已移除），需更新以避免資料欄位錯位
+                log_info("偵測到含 API_金鑰 欄位的舊版 Header，更新為新版...")
+                self._create_header(spreadsheet_id, sheet_name)
             else:
                 log_info("Google Sheets Header 已存在")
 
@@ -392,7 +396,6 @@ class GoogleSheetsService:
         header = [
             "時間戳記",
             "API_基礎網址",
-            "API_金鑰",
             "API_速率限制",
             "最大重試次數",
             "超時時間",
@@ -424,7 +427,8 @@ class GoogleSheetsService:
 
         try:
             range_name = f"{sheet_name}!A1:DD1"
-            body = {"values": [header]}
+            # 尾端補空字串，覆寫舊版 Header 可能殘留的多餘欄位
+            body = {"values": [header + [""] * 5]}
 
             self.service.spreadsheets().values().update(
                 spreadsheetId=spreadsheet_id, range=range_name, valueInputOption="RAW", body=body
@@ -448,9 +452,6 @@ class GoogleSheetsService:
         base_info = [
             timestamp,
             llm_api.get("base_url", ""),
-            (
-                llm_api.get("api_key", "")[:10] + "..." if llm_api.get("api_key") else ""
-            ),
             str(llm_api.get("api_rate_limit", "")),
             str(llm_api.get("max_retries", "")),
             str(llm_api.get("timeout", "")),

--- a/twinkle_eval/main.py
+++ b/twinkle_eval/main.py
@@ -220,18 +220,24 @@ class TwinkleEvalRunner:
         if self.config is None:
             raise ConfigurationError("配置未載入")
 
-        # 移除物件實例（不可序列化）
-        if "llm_instance" in self.config:
-            del self.config["llm_instance"]
-
-        save_config = copy.deepcopy(self.config)
+        # 排除物件實例（不可序列化）後再複製，避免就地修改 self.config
+        # 導致同一個 runner 無法重複執行
+        config_without_instances = {
+            k: v
+            for k, v in self.config.items()
+            if k
+            not in (
+                "llm_instance",
+                "evaluation_strategy_instance",
+                "extractor_instance",
+                "scorer_instance",
+            )
+        }
+        save_config = copy.deepcopy(config_without_instances)
 
         # 移除敏感資訊（API 金鑰）
         if "llm_api" in save_config and "api_key" in save_config["llm_api"]:
             del save_config["llm_api"]["api_key"]
-        for key in ("evaluation_strategy_instance", "extractor_instance", "scorer_instance"):
-            if key in save_config:
-                del save_config[key]
 
         return save_config
 
@@ -280,11 +286,23 @@ class TwinkleEvalRunner:
             except (OSError, ValueError):
                 continue
 
-            for key in ("evaluation_method", "system_prompt_enabled", "samples_per_question",
-                        "pass_k", "repeat_runs", "shuffle_options"):
+            for key in (
+                "evaluation_method",
+                "system_prompt_enabled",
+                "samples_per_question",
+                "pass_k",
+                "repeat_runs",
+                "shuffle_options",
+            ):
                 if key in cfg:
                     settings[key] = cfg[key]
-            for mk in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
+            for mk in (
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
                 if mk in cfg:
                     settings["model_overrides"][mk] = cfg[mk]
 
@@ -337,9 +355,11 @@ class TwinkleEvalRunner:
                     run_key = f"eval_results_{self.start_time}_run{run}.jsonl"
                     if run_key in completed_records:
                         from .datasets.file import Dataset as _Dataset
+
                         ds_len = len(_Dataset(file_path))
                         completed_for_file = sum(
-                            1 for rec in completed_records[run_key]
+                            1
+                            for rec in completed_records[run_key]
                             if rec.startswith(f"{file_path}|")
                         )
                         if completed_for_file >= ds_len:
@@ -449,6 +469,7 @@ class TwinkleEvalRunner:
         strategy_config = self.config["evaluation"].get("strategy_config", {})
         # 快取已建立的 (extractor, scorer) 配對，避免重複實例化
         from .metrics import create_metric_pair
+
         default_method = self.config["evaluation"]["evaluation_method"]
         metric_cache = {default_method: create_metric_pair(default_method, strategy_config)}
 
@@ -477,7 +498,8 @@ class TwinkleEvalRunner:
                 )
 
                 dataset_result = self._evaluate_dataset(
-                    dataset_path, evaluator,
+                    dataset_path,
+                    evaluator,
                     repeat_runs=ds["repeat_runs"],
                     pass_k=ds["pass_k"],
                     completed_records=completed_records,
@@ -1173,6 +1195,7 @@ def main() -> int:
     if args.finalize_results:
         try:
             from .runners.finalize import finalize_results
+
             return finalize_results(
                 args.finalize_results,
                 getattr(args, "hf_repo_id", None),
@@ -1226,7 +1249,11 @@ def main() -> int:
     # Benchmark 命令
     if args.benchmark:
         try:
-            from .runners.benchmark import BenchmarkRunner, print_benchmark_summary, save_benchmark_results
+            from .runners.benchmark import (
+                BenchmarkRunner,
+                print_benchmark_summary,
+                save_benchmark_results,
+            )
             from .core.config import load_config
 
             config = load_config(args.config)
@@ -1253,14 +1280,25 @@ def main() -> int:
             # 顯示結果摘要
             print_benchmark_summary(metrics)
 
-            # 儲存結果
+            # 儲存結果（排除不可序列化實例並移除 API 金鑰，避免敏感資訊寫入結果檔）
             timestamp = time.strftime("%Y%m%d_%H%M%S")
             output_path = f"benchmark_results_{timestamp}.json"
-            if "llm_instance" in config:
-                del config["llm_instance"]
-            if "evaluation_strategy_instance" in config:
-                del config["evaluation_strategy_instance"]
-            save_benchmark_results(metrics, output_path, config)
+            safe_config = copy.deepcopy(
+                {
+                    k: v
+                    for k, v in config.items()
+                    if k
+                    not in (
+                        "llm_instance",
+                        "evaluation_strategy_instance",
+                        "extractor_instance",
+                        "scorer_instance",
+                    )
+                }
+            )
+            if "llm_api" in safe_config and "api_key" in safe_config["llm_api"]:
+                del safe_config["llm_api"]["api_key"]
+            save_benchmark_results(metrics, output_path, safe_config)
 
             return 0
 

--- a/twinkle_eval/metrics/extractors/bfcl_prompt.py
+++ b/twinkle_eval/metrics/extractors/bfcl_prompt.py
@@ -173,8 +173,5 @@ class BFCLPromptExtractor(Extractor):
             return None
 
         # 轉換為統一格式：[{"name": "func", "arguments": {...}}]
-        standard = [
-            {"name": list(c.keys())[0], "arguments": list(c.values())[0]}
-            for c in calls
-        ]
+        standard = [{"name": list(c.keys())[0], "arguments": list(c.values())[0]} for c in calls]
         return json.dumps(standard, ensure_ascii=False)

--- a/twinkle_eval/metrics/extractors/box.py
+++ b/twinkle_eval/metrics/extractors/box.py
@@ -16,7 +16,9 @@ class BoxExtractor(Extractor):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(config)
-        self.patterns: List[str] = self._config.get("patterns", self.DEFAULT_PATTERNS)
+        self.patterns: List[str] = list(self._config.get("patterns", self.DEFAULT_PATTERNS))
+        # 預先編譯正則，避免在逐題熱路徑中重複解析
+        self._compiled: List["re.Pattern[str]"] = [re.compile(p) for p in self.patterns]
 
     def get_name(self) -> str:
         return "box"
@@ -26,8 +28,8 @@ class BoxExtractor(Extractor):
         if not self.validate_output(llm_output):
             return None
 
-        for pattern in self.patterns:
-            match = re.search(pattern, llm_output)
+        for pattern in self._compiled:
+            match = pattern.search(llm_output)
             if match:
                 return match.group(1).strip()
         return None
@@ -36,3 +38,4 @@ class BoxExtractor(Extractor):
         """新增自訂 box 模式。"""
         if pattern not in self.patterns:
             self.patterns.append(pattern)
+            self._compiled.append(re.compile(pattern))

--- a/twinkle_eval/metrics/extractors/custom.py
+++ b/twinkle_eval/metrics/extractors/custom.py
@@ -16,7 +16,9 @@ class CustomRegexExtractor(Extractor):
         super().__init__(config)
         if not self._config.get("patterns"):
             raise ValueError("CustomRegexExtractor 需要在 config 中提供 'patterns' 列表")
-        self.patterns: List[str] = self._config["patterns"]
+        self.patterns: List[str] = list(self._config["patterns"])
+        # 預先編譯正則，避免在逐題熱路徑中重複解析
+        self._compiled: List["re.Pattern[str]"] = [re.compile(p) for p in self.patterns]
 
     def get_name(self) -> str:
         return "custom_regex"
@@ -26,8 +28,8 @@ class CustomRegexExtractor(Extractor):
         if not self.validate_output(llm_output):
             return None
 
-        for pattern in self.patterns:
-            match = re.search(pattern, llm_output)
+        for pattern in self._compiled:
+            match = pattern.search(llm_output)
             if match:
                 return match.group(1).strip()
         return None

--- a/twinkle_eval/metrics/extractors/math.py
+++ b/twinkle_eval/metrics/extractors/math.py
@@ -33,7 +33,7 @@ class MathExtractor(Extractor):
                     depth -= 1
                 i += 1
             if depth == 0:
-                results.append(text[start:i - 1])
+                results.append(text[start : i - 1])
         return results
 
     def extract(self, llm_output: str) -> Optional[str]:

--- a/twinkle_eval/metrics/extractors/pattern.py
+++ b/twinkle_eval/metrics/extractors/pattern.py
@@ -56,7 +56,9 @@ class PatternExtractor(Extractor):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(config)
-        self.patterns: List[str] = self._config.get("patterns", self.DEFAULT_PATTERNS)
+        self.patterns: List[str] = list(self._config.get("patterns", self.DEFAULT_PATTERNS))
+        # 預先編譯正則，避免在逐題熱路徑中重複解析
+        self._compiled: List["re.Pattern[str]"] = [re.compile(p) for p in self.patterns]
 
     def get_name(self) -> str:
         return "pattern"
@@ -66,8 +68,8 @@ class PatternExtractor(Extractor):
         if not self.validate_output(llm_output):
             return None
 
-        for pattern in self.patterns:
-            match = re.search(pattern, llm_output)
+        for pattern in self._compiled:
+            match = pattern.search(llm_output)
             if match:
                 return match.group(1).strip()
         return None
@@ -76,3 +78,4 @@ class PatternExtractor(Extractor):
         """新增自訂模式。"""
         if pattern not in self.patterns:
             self.patterns.append(pattern)
+            self._compiled.append(re.compile(pattern))

--- a/twinkle_eval/metrics/extractors/regex_match.py
+++ b/twinkle_eval/metrics/extractors/regex_match.py
@@ -5,6 +5,17 @@ from typing import Any, Dict, List, Optional
 
 from twinkle_eval.core.abc import Extractor
 
+# 模組層級預編譯的清理用正則（extract 熱路徑逐行使用）
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MD_CODE_RE = re.compile(r"`(.+?)`")
+_LIST_PREFIX_RE = re.compile(r"^[-*•]\s+")
+_TRAILING_DOT_RE = re.compile(r"\.\s*$")
+_BOXED_RE = re.compile(r"\\boxed\{(.+?)\}")
+_MC_PREFIX_RE = re.compile(r"^(\([A-Z]\))\s")
+_SHORT_ANSWER_RE = re.compile(
+    r"^(\([A-Z]\)|Yes|No|True|False|[Vv]alid|[Ii]nvalid|-?\d+|[\]\[\)\(><}{]+)$"
+)
+
 
 class RegexMatchExtractor(Extractor):
     """使用可設定的正則表達式從 LLM 輸出中提取完整答案字串。
@@ -40,7 +51,12 @@ class RegexMatchExtractor(Extractor):
         raw = self._config.get("answer_pattern", self.DEFAULT_PATTERNS)
         if isinstance(raw, str):
             raw = [raw]
-        self.patterns: List[str] = raw
+        self.patterns: List[str] = list(raw)
+        # 預先編譯兩階段搜尋的正則（不跨行 / 跨行），避免逐題重複解析
+        self._compiled_stages: List[List["re.Pattern[str]"]] = [
+            [re.compile(p, flags) for p in self.patterns]
+            for flags in (re.IGNORECASE, re.IGNORECASE | re.DOTALL)
+        ]
 
     def get_name(self) -> str:
         return "regex_match"
@@ -55,9 +71,9 @@ class RegexMatchExtractor(Extractor):
             return None
 
         # 兩階段搜尋：先不跨行（取最後一個 match），再跨行（處理答案在下一行的情況）
-        for flags in (re.IGNORECASE, re.IGNORECASE | re.DOTALL):
-            for pattern in self.patterns:
-                matches = list(re.finditer(pattern, llm_output, flags))
+        for compiled_patterns in self._compiled_stages:
+            for pattern in compiled_patterns:
+                matches = list(pattern.finditer(llm_output))
                 if not matches:
                     continue
 
@@ -69,15 +85,12 @@ class RegexMatchExtractor(Extractor):
         # 最後嘗試：若最後幾行含有看起來像答案的內容
         lines = [line.strip() for line in llm_output.strip().splitlines() if line.strip()]
         for line in reversed(lines[-5:]):
-            cleaned = re.sub(r"\*\*(.+?)\*\*", r"\1", line)
-            cleaned = re.sub(r"`(.+?)`", r"\1", cleaned)
-            cleaned = re.sub(r"^[-*•]\s+", "", cleaned).strip()
-            cleaned = re.sub(r"\.\s*$", "", cleaned)
+            cleaned = _MD_BOLD_RE.sub(r"\1", line)
+            cleaned = _MD_CODE_RE.sub(r"\1", cleaned)
+            cleaned = _LIST_PREFIX_RE.sub("", cleaned).strip()
+            cleaned = _TRAILING_DOT_RE.sub("", cleaned)
             # 只接受看起來像簡短答案的行（MC、binary、數字、短文字）
-            if re.match(
-                r"^(\([A-Z]\)|Yes|No|True|False|[Vv]alid|[Ii]nvalid|-?\d+|[\]\[\)\(><}{]+)$",
-                cleaned,
-            ):
+            if _SHORT_ANSWER_RE.match(cleaned):
                 return cleaned
 
         return None
@@ -95,28 +108,28 @@ class RegexMatchExtractor(Extractor):
         answer = lines[0]
 
         # 移除 markdown 粗體 **X** → X
-        answer = re.sub(r"\*\*(.+?)\*\*", r"\1", answer)
+        answer = _MD_BOLD_RE.sub(r"\1", answer)
 
         # 移除 markdown 行內程式碼 `X` → X
-        answer = re.sub(r"`(.+?)`", r"\1", answer)
+        answer = _MD_CODE_RE.sub(r"\1", answer)
 
         # 移除 \boxed{X} → X
-        boxed = re.search(r"\\boxed\{(.+?)\}", answer)
+        boxed = _BOXED_RE.search(answer)
         if boxed:
             answer = boxed.group(1)
 
         # 移除結尾句號
-        answer = re.sub(r"\.\s*$", "", answer)
+        answer = _TRAILING_DOT_RE.sub("", answer)
 
         # 移除首尾引號
         if len(answer) >= 2 and answer[0] == answer[-1] and answer[0] in "\"'":
             answer = answer[1:-1]
 
         # 移除列表前綴（如 "- No" → "No"）
-        answer = re.sub(r"^[-*•]\s+", "", answer)
+        answer = _LIST_PREFIX_RE.sub("", answer)
 
         # 若答案以 MC 格式開頭 (X)，只保留 (X) 部分
-        mc_match = re.match(r"^(\([A-Z]\))\s", answer)
+        mc_match = _MC_PREFIX_RE.match(answer)
         if mc_match:
             answer = mc_match.group(1)
 

--- a/twinkle_eval/metrics/scorers/text2sql.py
+++ b/twinkle_eval/metrics/scorers/text2sql.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sqlite3
+import time
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from twinkle_eval.core.abc import Scorer
@@ -60,9 +61,7 @@ def _parse_gold(gold: Any) -> Tuple[str, Optional[str]]:
     return text, None
 
 
-def execute_sql(
-    db_path: str, sql: str, timeout: int = 30
-) -> Optional[List[Tuple[Any, ...]]]:
+def execute_sql(db_path: str, sql: str, timeout: int = 30) -> Optional[List[Tuple[Any, ...]]]:
     """對 SQLite 資料庫執行 SQL，回傳結果集。
 
     Returns:
@@ -70,20 +69,27 @@ def execute_sql(
     """
     if not os.path.isfile(db_path):
         return None
+    conn: Optional[sqlite3.Connection] = None
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=timeout)
         conn.execute("PRAGMA query_only = ON")
+        # 以 progress handler 實作查詢逾時：超過 deadline 即中止查詢
+        # （sqlite3.connect 的 timeout 參數只處理鎖競爭，管不到長時間查詢）
+        deadline = time.monotonic() + timeout
+        conn.set_progress_handler(lambda: 1 if time.monotonic() > deadline else 0, 100_000)
         cursor = conn.cursor()
         cursor.execute(sql)
         results = cursor.fetchall()
-        conn.close()
         return results
-    except (sqlite3.Error, Exception):
-        try:
-            conn.close()
-        except Exception:
-            pass
+    except sqlite3.Error:
+        # SQL 執行失敗（語法錯誤、逾時中止等）視為無結果，由呼叫端評為不正確
         return None
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 def result_sets_match(

--- a/twinkle_eval/runners/finalize.py
+++ b/twinkle_eval/runners/finalize.py
@@ -9,13 +9,17 @@ import numpy as np
 from twinkle_eval.exporters import ResultsExporterFactory
 
 
-def finalize_results(timestamp: str, hf_repo_id: Optional[str] = None, hf_variant: Optional[str] = "default") -> int:
+def finalize_results(
+    timestamp: str, hf_repo_id: Optional[str] = None, hf_variant: Optional[str] = "default"
+) -> int:
     """合併平行運算產生的碎片並重新計算評測指標，最後刪除碎片。
     若無碎片但存在單節點最終結果，則直接執行上傳。
     """
 
     results_dir = "results"
-    json_shards = sorted(glob.glob(os.path.join(results_dir, f"results_{timestamp}_node*_rank*.json")))
+    json_shards = sorted(
+        glob.glob(os.path.join(results_dir, f"results_{timestamp}_node*_rank*.json"))
+    )
 
     if not json_shards:
         # 單節點執行：直接上傳已存在的最終結果，無須合併
@@ -28,6 +32,7 @@ def finalize_results(timestamp: str, hf_repo_id: Optional[str] = None, hf_varian
         if hf_repo_id:
             try:
                 from twinkle_eval.integrations.huggingface import upload_results
+
                 with open(single_node_result, "r", encoding="utf-8") as _f:
                     _result = json.load(_f)
                 model_name = _result.get("config", {}).get("model", {}).get("name", "unknown_model")
@@ -143,18 +148,24 @@ def finalize_results(timestamp: str, hf_repo_id: Optional[str] = None, hf_varian
                 mean_acc = float(np.mean(run_accuracies)) if run_accuracies else 0.0
                 std_acc = float(np.std(run_accuracies)) if len(run_accuracies) > 1 else 0.0
 
-                ds_results.append({
-                    "file": file_path,
-                    "accuracy_mean": mean_acc,
-                    "accuracy_std": std_acc,
-                    "individual_runs": {
-                        "accuracies": run_accuracies,
-                        "results": run_merged_jsonl_paths,
-                    },
-                })
+                ds_results.append(
+                    {
+                        "file": file_path,
+                        "accuracy_mean": mean_acc,
+                        "accuracy_std": std_acc,
+                        "individual_runs": {
+                            "accuracies": run_accuracies,
+                            "results": run_merged_jsonl_paths,
+                        },
+                    }
+                )
 
-            ds_avg_acc = float(np.mean([r["accuracy_mean"] for r in ds_results])) if ds_results else 0.0
-            ds_avg_std = float(np.mean([r["accuracy_std"] for r in ds_results])) if ds_results else 0.0
+            ds_avg_acc = (
+                float(np.mean([r["accuracy_mean"] for r in ds_results])) if ds_results else 0.0
+            )
+            ds_avg_std = (
+                float(np.mean([r["accuracy_std"] for r in ds_results])) if ds_results else 0.0
+            )
 
             merged_dataset_results[ds_name] = {
                 "results": ds_results,
@@ -181,17 +192,22 @@ def finalize_results(timestamp: str, hf_repo_id: Optional[str] = None, hf_varian
         for sp in json_shards:
             try:
                 os.remove(sp)
-            except OSError:
-                pass
+            except OSError as e:
+                print(f"⚠️  無法刪除碎片 {sp}: {e}")
+        # rank0 的分片檔名沒有 shard 後綴，可能與合併輸出同名，不得刪除
+        merged_abs = {os.path.abspath(p) for p in merged_jsonl_files}
         for jp in shard_jsonl_files:
+            if os.path.abspath(jp) in merged_abs:
+                continue
             try:
                 os.remove(jp)
-            except OSError:
-                pass
+            except OSError as e:
+                print(f"⚠️  無法刪除碎片 {jp}: {e}")
 
     if hf_repo_id:
         try:
             from twinkle_eval.integrations.huggingface import upload_results
+
             model_name = base_result["config"].get("model", {}).get("name", "unknown_model")
             upload_results(
                 repo_id=hf_repo_id,

--- a/twinkle_eval/runners/standard.py
+++ b/twinkle_eval/runners/standard.py
@@ -49,19 +49,23 @@ class TwinkleEvalRunner:
         if self.config is None:
             raise ConfigurationError("配置未載入")
 
-        if "llm_instance" in self.config:
-            del self.config["llm_instance"]
-
-        save_config = copy.deepcopy(self.config)
+        # 排除物件實例（不可序列化）後再複製，避免就地修改 self.config
+        # 導致同一個 runner 無法重複執行
+        config_without_instances = {
+            k: v
+            for k, v in self.config.items()
+            if k
+            not in (
+                "llm_instance",
+                "evaluation_strategy_instance",
+                "extractor_instance",
+                "scorer_instance",
+            )
+        }
+        save_config = copy.deepcopy(config_without_instances)
 
         if "llm_api" in save_config and "api_key" in save_config["llm_api"]:
             del save_config["llm_api"]["api_key"]
-        if "evaluation_strategy_instance" in save_config:
-            del save_config["evaluation_strategy_instance"]
-        # 新架構：移除 extractor_instance / scorer_instance
-        for key in ("extractor_instance", "scorer_instance"):
-            if key in save_config:
-                del save_config[key]
 
         return save_config
 
@@ -114,7 +118,13 @@ class TwinkleEvalRunner:
             ):
                 if key in cfg:
                     settings[key] = cfg[key]
-            for mk in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
+            for mk in (
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
                 if mk in cfg:
                     settings["model_overrides"][mk] = cfg[mk]
 
@@ -259,7 +269,8 @@ class TwinkleEvalRunner:
                 )
 
                 dataset_result = self._evaluate_dataset(
-                    dataset_path, evaluator,
+                    dataset_path,
+                    evaluator,
                     repeat_runs=ds["repeat_runs"],
                     pass_k=ds["pass_k"],
                 )
@@ -320,9 +331,7 @@ class TwinkleEvalRunner:
         log_info(f"評測完成，結果已匯出至: {', '.join(exported_files)}")
         return exported_files[0] if exported_files else ""
 
-    def _handle_google_services(
-        self, results: Dict[str, Any], export_formats: List[str]
-    ) -> None:
+    def _handle_google_services(self, results: Dict[str, Any], export_formats: List[str]) -> None:
         """處理 Google 服務整合。"""
         if self.config is None:
             return


### PR DESCRIPTION
## 這是 #136 的前半段，獨立拆出來先合

PR #136（@dave-apmic）是一個 27 commit、66 檔的大批次。我審過之後給了 `CHANGES_REQUESTED`，因為其中的 evaluator 重構帶著 5 個會產生**錯誤數字**的靜默問題。但那個 PR 的前半段是一批**獨立、不改變評測分數**的 bug fix，品質很好，沒必要被卡住。

本 PR 就是那批，以 `cherry-pick -x` 取出，**作者資訊完整保留為 @dave-apmic / S.Feng**。原 PR 的其餘部分繼續在 #136 討論。

## 修掉的東西（每一項都在 `origin/main` 上實測重現過）

| 問題 | 嚴重度 |
|------|--------|
| **`--benchmark` 把完整 API 金鑰寫進 `benchmark_results_*.json`** —— 該路徑未經 `_prepare_config_for_saving()` 清理 | 🔴 原則 E 破口 |
| **`finalize` 刪除合併後的 JSONL** —— rank0 的 shard 路徑與合併輸出路徑相同，清理時把剛合併好的結果一併刪掉 | 🔴 原則 D 資料遺失 |
| **`_prepare_config_for_saving()` 就地刪除 `self.config["llm_instance"]`** —— 同一個 runner 無法重複執行，第二次 `run_evaluation()` 直接 `KeyError` | 🔴 |
| **HTML exporter 在 `usage_total_tokens` 為 `None` 時 `TypeError` 崩潰**；模型輸出未經 `html.escape()`，含 `<script>` 會注入報告 | 🟡 |
| **`cli.py` 的 `sys.path` hack 遮蔽 HuggingFace `datasets` 套件** —— `import datasets` 解析到專案內的 `twinkle_eval/datasets/`，循環 import 失敗 | 🟡 |
| **text2sql 的 SQL 執行逾時從未生效** | 🟡 |
| **gated dataset 檢查的運算子優先序錯誤** —— 任何含 `403` 的錯誤都被當成 gated 而靜默略過 | 🟡 |

評測核心未被觸及：`runners/evaluator.py` 與 `datasets/file.py` 在本分支上與 `origin/main` **位元相同**。

## ⚠️ 四個行為變更，請特別過目

1. **`--dry-run` 與評測啟動不再做 Google 連線檢查。** 這修好了 §4「config.py 不做 API 呼叫」與 §12「`--dry-run` 不呼叫 API」兩個契約。代價是原本會在評測開始前擋下的診斷（含 Service Account email 與三步解法）不再出現，改為評測結束的上傳階段才以 log 呈現。
   > 依 §7，「修改現有 CLI 選項的行為」需要先開 Issue。舊行為本身違反已載明的契約，所以我傾向以本 PR 的明確簽核取代另開 Issue —— **但這應該是你的明確決定，不是默默通過。**

2. **Google Sheets 匯出移除 `API_金鑰` 欄位**（30 → 29 欄）。既有試算表的歷史列仍保有截斷的金鑰，且在新表頭下會位移一欄，**建議封存或清空舊表**。

3. **`--download-dataset` 對非 gated 的 403 改為 exit 1**，先前靜默略過。

4. **text2sql 的 EX 評分真的會在 `text2sql_timeout`（預設 30 秒）中止。** 若 gold SQL 本身逾時，該題退回 Exact Match，可能使 text2sql 分數有小幅變動。

## 這批「沒有」修什麼

秒級時間戳**只套用到 log 檔名**。`results_*.json` 與 JSONL 仍是分鐘精度，同分鐘啟動兩次會出問題，且兩者失效方式不同（JSON 被覆蓋、JSONL 累加後導致下游重複計數）。詳見 CHANGELOG。

那個 cherry-pick 過來的 commit 標題寫「result and log filenames」，對本批而言誇大了 —— runner 端的時間戳在 #136 後半段。我**沒有改寫該 commit 訊息**，以保留與 #136 的對照性，改在 CHANGELOG 講清楚。

## 測試

新增 `tests/test_config_sanitization.py`（9 個測試）—— 原則 E 在此之前**零覆蓋**，而本批的頭號修復正是金鑰外洩。對 `origin/main` 複驗，其中 **3 個會失敗**：

```
FAILED test_does_not_mutate_live_config
FAILED test_header_has_no_api_key_column
FAILED test_main_benchmark_branch_sanitizes
```

```
623 passed, 2 failed, 1 skipped
```

兩個失敗在本次變更前就存在（過期的 editable install metadata、缺 `/tmp/eval_two_files/` fixture），性質未變。

Lint 嚴格改善：black 9 → 1 檔、flake8 45 → 15 項，零新增問題。

## 版號

依 §11 bump 到 **2.8.1**（PATCH）。13 個 commit 逐條對照過 MAJOR/MINOR 條件，沒有一個構成：無新 benchmark、無新評測方法、無新 exporter、無新 optional-dependency group、無 config schema 變更、無 ABC 變更、輸出結構與檔名未變。

Tag 與 `gh release create` 於合入後補上。

## ⚠️ 合併順序很重要

本 PR 必須在 #149（`fix/shuffle-options-and-runner-dedup`，2.9.0）**之前**合入。

#149 把 `TwinkleEvalRunner` 從 `main.py` 搬進 `runners/standard.py`，但它搬過去的是**舊版**的 `_prepare_config_for_saving()`（會就地 `del self.config["llm_instance"]`），而且它的 `main.py` 也還帶著未清理的 benchmark 存檔路徑。

**若順序顛倒，或 rebase 時照文字衝突隨手解掉，本 PR 的原則 E 修復會被靜默吃掉。**

本 PR 先合的話，`test_does_not_mutate_live_config` 與 `test_main_benchmark_branch_sanitizes` 會在 rebase 解錯時大聲失敗 —— 這是選擇這個順序最有力的理由。反過來合則沒有任何東西守著。

## Follow-up（已開或待開）

- #157 —— logger 延遲初始化後，若宿主已設定 root logger 則 log 檔案靜默不寫入（影響 Colab / CI / 函式庫使用）
- `finalize` 的資料遺失與 HTML exporter 崩潰目前仍無測試覆蓋，建議補上
- `47a017d` 刪掉的 Google 診斷訊息應搬到上傳路徑而非消失
