### PR TITLE
fix(models): system_prompt 對所有評測方法生效，並修好 vision 路徑（#144）

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+# E203：black 會在切片的冒號前留空白（`a[i + 1 :]`），與 PEP 8 的字面解讀衝突。
+# black 官方明確建議忽略此項。
+extend-ignore = E203

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`evaluation.system_prompt` 只對 `box` 與 `math` 生效**（#144）：`_build_messages()` 以
+  `method in {"box", "math"}` 的硬編碼白名單決定是否送出，其餘方法即使設了也不進 request。
+  `templates/regex_match.yaml` 這個官方範本自己就設了一段指定輸出格式的 prompt 卻從未送出，
+  使用者照範本設定反而得到爆高的 `unparsed_rate` 且無從得知原因。
+  改為：只要設了非空 `system_prompt` 且 `system_prompt_enabled` 為真就送出。
+- **vision 路徑在任何設定下都送不出 system prompt**：它不經過 `_build_messages()`，
+  evaluator 自己組 multimodal messages 直接傳給 `call()`。`_build_vision_messages()`
+  新增 optional 的 `system_prompt` 參數。
+- `templates/regex_match.yaml` 補上 `datasets_prompt_map`。該範本只定義 `en` 鍵，而
+  `prompt_lang` 預設為 `zh`，所以即使移除白名單，prompt 仍然送不出去。
+
+### Changed
+- **設了 `system_prompt` 的非 box/math 設定，現在該 prompt 會真的送達模型**，分數會變動。
+  這是修復而非副作用——那些設定本來就預期 prompt 會被送出。`regex_match` 使用者應預期
+  `unparsed_rate` 下降。
+- **`box` / `math` 在未設 `system_prompt` 時不再送出 `content` 為空字串的 system message。**
+  舊版會送出空的 system block，多數 chat template 仍會渲染它，因此這可能使既有的
+  box / math 分數有小幅變動。
+- system prompt 的語言解析改為區分「鍵不存在」與「鍵存在但為空」：前者依序回退 `zh`、
+  再回退唯一已定義的語言；後者視為該語言明確不要 prompt，**不跨語言回退**。
+  先前的 `or` 串接會讓 `{zh: "中文", en: null}` 搭配英文資料集收到中文 prompt。
 ## [2.8.1] - 2026-09-11
 
 本版為 PR #136（`Fix/audit bugfix batch`，作者 @dave-apmic）前半段的獨立修復批次，

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,122 @@
+"""system_prompt 送達路徑的測試（#144）。
+
+修正前 `_build_messages()` 以 `method in {"box", "math"}` 的白名單決定是否送出
+system prompt，而 vision 路徑根本不經過該函式。結果是除了 box / math 之外的
+所有評測方法——包含官方範本就設了 system_prompt 的 regex_match——設了也不會
+進 request。
+"""
+
+import pathlib
+
+import pytest
+
+from twinkle_eval.core.prompts import resolve_system_prompt
+from twinkle_eval.models.openai import OpenAIModel
+from twinkle_eval.runners.evaluator import _build_vision_messages
+
+
+class TestResolveSystemPrompt:
+    @pytest.mark.parametrize(
+        "cfg,lang,enabled,expected",
+        [
+            ({"system_prompt": {"zh": "中文", "en": "english"}}, "zh", True, "中文"),
+            ({"system_prompt": {"zh": "中文", "en": "english"}}, "en", True, "english"),
+            ({"system_prompt": {"zh": "中文"}}, "ja", True, "中文"),  # 回退 zh
+            ({"system_prompt": "純字串"}, "zh", True, "純字串"),
+            ({"system_prompt": {"zh": "中文"}}, "zh", False, None),  # 明確停用
+            ({}, "zh", True, None),  # 未設定
+            ({"system_prompt": {}}, "zh", True, None),
+            ({"system_prompt": {"zh": "   "}}, "zh", True, None),  # 空白視同未設定
+            ({"system_prompt": None}, "zh", True, None),
+            # 鍵存在但為 null：明確不要 prompt，不得跨語言回退（否則英文題目會收到中文 prompt）
+            ({"system_prompt": {"zh": "中文", "en": None}}, "en", True, None),
+            ({"system_prompt": {"zh": "中文", "en": ""}}, "en", True, None),
+            # 鍵不存在且只定義了一種語言：回退到該語言（regex_match.yaml 的情況）
+            ({"system_prompt": {"en": "only english"}}, "zh", True, "only english"),
+            # 鍵不存在但定義了多種語言：回退 zh
+            ({"system_prompt": {"zh": "中文", "ja": "日本語"}}, "ko", True, "中文"),
+        ],
+    )
+    def test_resolution(self, cfg, lang, enabled, expected):
+        assert resolve_system_prompt(cfg, lang, enabled) == expected
+
+
+def make_model(evaluation):
+    m = OpenAIModel.__new__(OpenAIModel)
+    m.config = {
+        "llm_api": {"api_key": "x", "base_url": "u"},
+        "model": {"name": "m"},
+        "evaluation": evaluation,
+    }
+    return m
+
+
+class TestBuildMessages:
+    """文字路徑：不再依評測方法白名單。"""
+
+    @pytest.mark.parametrize("method", ["box", "math", "regex_match", "pattern", "custom_regex"])
+    def test_system_prompt_sent_for_every_method_when_configured(self, method):
+        m = make_model({"evaluation_method": method, "system_prompt": {"zh": "格式要求"}})
+        msgs = m._build_messages("題目", "zh", method, True)
+        assert [x["role"] for x in msgs] == ["system", "user"]
+        assert msgs[0]["content"] == "格式要求"
+
+    @pytest.mark.parametrize("method", ["box", "math", "regex_match", "pattern"])
+    def test_no_system_message_when_not_configured(self, method):
+        """未設定時的行為與修正前相同，不得平白多出一個空的 system message。"""
+        m = make_model({"evaluation_method": method})
+        assert [x["role"] for x in m._build_messages("題目", "zh", method, True)] == ["user"]
+
+    def test_disabled_flag_wins(self):
+        m = make_model({"evaluation_method": "box", "system_prompt": {"zh": "格式要求"}})
+        assert [x["role"] for x in m._build_messages("題目", "zh", "box", False)] == ["user"]
+
+    def test_shipped_regex_match_template_actually_sends_its_prompt(self):
+        """回歸 #144：讀**實際出貨的範本**，不寫死語言。
+
+        先前的版本把 prompt_lang 寫死成 "en" 才通過，掩蓋了真正的問題——
+        範本只定義 en 鍵、又沒有 datasets_prompt_map，而 prompt_lang 預設是
+        "zh"，所以使用者照官方範本設定仍然收不到 prompt。
+        """
+        import yaml
+
+        tpl = pathlib.Path("twinkle_eval/templates/regex_match.yaml")
+        ev = yaml.safe_load(tpl.read_text(encoding="utf-8"))["evaluation"]
+
+        # 預設語言（未指定 datasets_prompt_map 時）
+        assert resolve_system_prompt(ev, "zh", True), "預設語言下範本的 prompt 仍送不出"
+        # 範本自己宣告的語言對應
+        lang = ev["datasets_prompt_map"]["datasets/example/bbh/"]
+        assert resolve_system_prompt(ev, lang, True)
+
+    def test_box_with_no_system_prompt_sends_no_empty_system_message(self):
+        """行為變更：舊版對 box/math 會送出 content 為空字串的 system message。
+
+        空的 system block 在多數 chat template 下仍會被渲染，可能影響分數。
+        新版不送，這是改善但屬行為變更，已記錄於 CHANGELOG。
+        """
+        m = make_model({"evaluation_method": "box"})
+        assert m._build_messages("題目", "zh", "box", True) == [{"role": "user", "content": "題目"}]
+
+
+class TestVisionMessages:
+    """vision 路徑自己組 messages，是 #144 的另一半。"""
+
+    def test_system_prompt_prepended(self):
+        msgs = _build_vision_messages(
+            "data:image/jpeg;base64,X", "Q", "auto", system_prompt="用 \\boxed{}"
+        )
+        assert [x["role"] for x in msgs] == ["system", "user"]
+        assert msgs[0]["content"] == "用 \\boxed{}"
+
+    def test_without_system_prompt_matches_previous_shape(self):
+        msgs = _build_vision_messages("data:image/jpeg;base64,X", "Q", "auto")
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert [c["type"] for c in msgs[0]["content"]] == ["image_url", "text"]
+
+    def test_image_content_unchanged_when_system_prompt_added(self):
+        """加入 system message 不得動到原本的 image_url / text 結構。"""
+        a = _build_vision_messages("u", "Q", "high")
+        b = _build_vision_messages("u", "Q", "high", system_prompt="p")
+        assert a[0] == b[1]

--- a/twinkle_eval/core/prompts.py
+++ b/twinkle_eval/core/prompts.py
@@ -1,0 +1,56 @@
+"""System prompt 的解析。
+
+獨立成模組是為了避免循環 import：``core/config.py`` 需要匯入 ``models``
+取得 ``LLMFactory``，而 ``models`` 又需要這個函式。本模組只依賴 typing。
+"""
+
+from typing import Any, Dict, Optional
+
+_MISSING = object()
+
+
+def resolve_system_prompt(
+    eval_config: Dict[str, Any],
+    prompt_lang: str,
+    system_prompt_enabled: bool = True,
+) -> Optional[str]:
+    """從 evaluation 設定解析出要送出的 system prompt。
+
+    語言鍵的解析規則刻意區分「鍵不存在」與「鍵存在但為空」：
+
+    - 鍵**不存在** → 依序回退 ``zh``、再回退唯一已定義的語言。
+      這讓只定義了 ``en`` 的設定（例如 ``templates/regex_match.yaml``）
+      在預設 ``prompt_lang="zh"`` 下仍能送出 prompt。
+    - 鍵**存在但為 None 或空白** → 視為該語言明確不要 prompt，回傳 None，
+      **不跨語言回退**。否則 ``{zh: "中文", en: null}`` 搭配英文資料集
+      會把中文 prompt 送給英文題目。
+
+    Args:
+        eval_config:           config 的 ``evaluation`` 區塊。
+        prompt_lang:           語言代碼。
+        system_prompt_enabled: 為 False 時一律不送。
+
+    Returns:
+        要送出的 system prompt；未設定、為空或被停用時回傳 None。
+    """
+    if not system_prompt_enabled:
+        return None
+
+    cfg = eval_config.get("system_prompt")
+    if cfg is None:
+        return None
+    if not isinstance(cfg, dict):
+        text = str(cfg).strip()
+        return text or None
+
+    value = cfg.get(prompt_lang, _MISSING)
+    if value is _MISSING:
+        value = cfg.get("zh", _MISSING)
+    if value is _MISSING:
+        defined = [v for v in cfg.values() if v is not None and str(v).strip()]
+        value = defined[0] if len(defined) == 1 else _MISSING
+    if value is _MISSING or value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None

--- a/twinkle_eval/models/openai.py
+++ b/twinkle_eval/models/openai.py
@@ -8,6 +8,7 @@ from openai.types.chat import ChatCompletion
 
 from twinkle_eval.core.abc import LLM
 from twinkle_eval.core.logger import log_error
+from twinkle_eval.core.prompts import resolve_system_prompt
 
 
 class OpenAIModel(LLM):
@@ -50,26 +51,26 @@ class OpenAIModel(LLM):
         eval_method: str,
         system_prompt_enabled: bool,
     ) -> list:
-        """依評測方法建立訊息列表。"""
-        eval_config = self.config["evaluation"]
-        method = eval_method or eval_config["evaluation_method"]
+        """建立訊息列表。
 
-        # box 和 math 兩種方法都使用 system prompt
-        uses_system_prompt = system_prompt_enabled and method in {"box", "math"}
+        只要 config 設了非空的 ``system_prompt`` 且 ``system_prompt_enabled``
+        為真就送出，不再依評測方法白名單決定。
 
-        if uses_system_prompt:
-            sys_prompt_cfg = eval_config.get("system_prompt", {})
-            if isinstance(sys_prompt_cfg, dict):
-                sys_prompt = sys_prompt_cfg.get(prompt_lang, sys_prompt_cfg.get("zh", ""))
-            else:
-                sys_prompt = sys_prompt_cfg
-
-            return [
-                {"role": "system", "content": sys_prompt},
-                {"role": "user", "content": question_text},
-            ]
-        else:
+        先前的實作是 ``method in {"box", "math"}``，這造成兩個問題（#144）：
+        其他方法即使在 config 設了 ``system_prompt`` 也不會進 request——
+        ``templates/regex_match.yaml`` 就設了一段指定輸出格式的 prompt 卻從未
+        送出，使用者照官方範本設定反而得到爆高的 unparsed_rate；而且 models
+        層需要知道評測方法，違反 §4 的模組職責邊界。
+        """
+        sys_prompt = resolve_system_prompt(
+            self.config["evaluation"], prompt_lang, system_prompt_enabled
+        )
+        if sys_prompt is None:
             return [{"role": "user", "content": question_text}]
+        return [
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": question_text},
+        ]
 
     def call(
         self,
@@ -92,7 +93,9 @@ class OpenAIModel(LLM):
         if messages is not None:
             built_messages = messages
         else:
-            built_messages = self._build_messages(question_text, prompt_lang, eval_method, system_prompt_enabled)
+            built_messages = self._build_messages(
+                question_text, prompt_lang, eval_method, system_prompt_enabled
+            )
         model_config = self.config["model"]
         overrides = model_overrides or {}
 

--- a/twinkle_eval/runners/evaluator.py
+++ b/twinkle_eval/runners/evaluator.py
@@ -15,6 +15,7 @@ from twinkle_eval.core.logger import log_error
 from twinkle_eval.metrics.extractors.tool_call import ToolCallExtractor, convert_bfcl_functions_to_tools
 from twinkle_eval.metrics.extractors.bfcl_prompt import BFCLPromptExtractor, inject_bfcl_system_prompt
 from twinkle_eval.models import LLM
+from twinkle_eval.core.prompts import resolve_system_prompt
 
 
 def _get_node_id() -> str:
@@ -150,9 +151,18 @@ def _build_vision_messages(
     image_url: str,
     question_text: str,
     image_detail: str = "auto",
+    system_prompt: Optional[str] = None,
 ) -> list:
-    """建構 OpenAI multimodal messages（image_url + text）。"""
-    return [
+    """建構 OpenAI multimodal messages（image_url + text）。
+
+    vision 路徑不經過 ``OpenAIModel._build_messages()``——evaluator 自己組好
+    messages 直接傳給 ``call()``——所以 system prompt 必須在這裡加入，否則
+    ``evaluation.system_prompt`` 對視覺評測完全無效（#144 的另一半）。
+    """
+    messages: list = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append(
         {
             "role": "user",
             "content": [
@@ -163,7 +173,8 @@ def _build_vision_messages(
                 {"type": "text", "text": question_text},
             ],
         }
-    ]
+    )
+    return messages
 
 
 class RateLimiter:
@@ -812,7 +823,16 @@ class Evaluator:
                         log_error(f"問題 {idx + 1} 圖片載入失敗: {e}")
                         continue
 
-                    messages = _build_vision_messages(image_url, question_text, image_detail)
+                    messages = _build_vision_messages(
+                        image_url,
+                        question_text,
+                        image_detail,
+                        system_prompt=resolve_system_prompt(
+                            self.config.get("evaluation", {}),
+                            prompt_lang,
+                            self.system_prompt_enabled,
+                        ),
+                    )
 
                     self.rate_limiter.wait()
                     # Vision 路徑使用預先建構的 multimodal messages，

--- a/twinkle_eval/templates/regex_match.yaml
+++ b/twinkle_eval/templates/regex_match.yaml
@@ -25,6 +25,11 @@ evaluation:
   # 預設 pattern 為 "the answer is (.*)"，匹配 BBH 標準 CoT 結尾格式。
   evaluation_method: "regex_match"
 
+  # BBH 是英文資料集，明示語言對應以取用 system_prompt 的 en 鍵。
+  # 未設定時 prompt_lang 預設為 "zh"。
+  datasets_prompt_map:
+    "datasets/example/bbh/": "en"
+
   system_prompt:
     en: "Follow each question's instructions carefully. Think step by step. You MUST end your response with exactly this format: 'the answer is {your answer}' where {your answer} is the option like (A), (B), etc., or the exact value like Yes, No, True, False, valid, invalid, or the computed result."
 


### PR DESCRIPTION
Fixes #144。

## 問題比 issue 描述的更廣，需要三處修正

1. **白名單** —— `_build_messages()` 硬編碼 `method in {"box", "math"}`，其餘方法設了 `system_prompt` 也不送。`templates/regex_match.yaml` 這個官方範本自己就設了一段指定輸出格式的 prompt，使用者照做卻得到爆高的 `unparsed_rate` 且無從得知原因。

2. **vision 路徑根本不經過 `_build_messages()`** —— evaluator 自己組 multimodal messages 直接傳給 `call()`。所以 `vision_mcq` 在**任何設定下**都送不出 system prompt，拿掉白名單也沒用。

3. **拿掉白名單後 `regex_match.yaml` 仍然送不出** —— 它只定義 `en` 鍵，而 `prompt_lang` 預設是 `zh`。這是 review 抓到的 BLOCKER：我第一版的測試把 `prompt_lang="en"` 寫死才通過，掩蓋了真正的問題。範本現在明示 `datasets_prompt_map`，測試改為**讀實際出貨的範本**。

## 語言解析：區分「鍵不存在」與「鍵存在但為空」

原本的 `or` 串接會讓 `{zh: "中文", en: null}` 搭配英文資料集**收到中文 prompt**。現在：

- 鍵不存在 → 回退 `zh`，再回退唯一已定義的語言
- 鍵存在但為 `null` 或空白 → 該語言明確不要 prompt，**不跨語言回退**

`resolve_system_prompt()` 放在獨立的 `core/prompts.py` —— `core/config.py` 需要匯入 `models` 取得 `LLMFactory`，放那裡會循環 import。

## ⚠️ 兩個行為變更

1. **設了 `system_prompt` 的非 box/math 設定，prompt 現在會真的送達，分數會變動。** 這是修復而非副作用。`regex_match` 使用者應預期 `unparsed_rate` 下降。
2. **`box` / `math` 未設 `system_prompt` 時，不再送出 `content` 為空字串的 system message。** 舊版會送，而多數 chat template 仍會渲染空的 system block，所以既有 box/math 分數可能小幅變動。

## §7 程序說明

#144 由我（maintainer）開立並實作，issue 內列了三個選項但**沒有第二位 maintainer 的書面回覆**。本 PR 採用選項 1。這等同自我核准，在此明確揭露而非默默通過。cc @teds-lin

## 測試

28 個測試，`642 passed`。兩個失敗在變更前就存在。

依 review 意見，`evaluator.py` 的無關 black 全檔重排已還原（209/135 → 24/4），讓 diff 只剩實質改動。

新增 `.flake8` 忽略 E203（black 在切片冒號前留空白，官方建議忽略）。

## 版號

CHANGELOG 先放 `[Unreleased]`。本分支基於 2.8.0，而 #158 會推到 2.8.1 —— 合併順序確定後再定版號。